### PR TITLE
PHANGS megatable integration

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,23 +1,18 @@
 name: deploy-book
 
-# Only run this when the master branch changes
 on:
   push:
     branches:
-    - main
-  pull_request:
-    branches:
       - main
+  pull_request:
   workflow_dispatch:
 
-# This job installs dependencies, build the book, and pushes it to `gh-pages`
 jobs:
   deploy-book:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
-    # Install dependencies
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
       with:
@@ -28,14 +23,13 @@ jobs:
         pip install -r requirements.txt
         pip install .
 
-
-    # Build the book
     - name: Build the book
       run: |
         PYTHONPATH=./ jupyter-book build book/
 
-    # Push the book's HTML to github-pages
+    # Deploy only on push to main (not on PRs)
     - name: GitHub Pages action
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,9 @@
 name: Ruff
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+          pip install .
+
+      - name: Run tests
+        run: pytest tests/ -v -m "not integration"

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,16 @@ prfm.egg-info
 _build
 __pycache__
 figure
+figures/
 .DS_Store
+
+# Local notebooks and scratch work
+book/prfm_playground.ipynb
+temporary/
+
+# Local data files
+data/CMZoom_Kennicutt.png
+data/phangs_megatable/
+
+# Notes
+viz_tip.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**PRFM** is a Python toolkit implementing the Pressure-Regulated Feedback Model for calculating vertical equilibrium and star formation rates in galactic gas disks.
+
+The main package is `prfm/` (NumPy-based). A JAX port lives on the `jax-experimental` branch (`prfm_jax/`) — see `prfm_jax/NOTES.md` there for status and next steps.
+
+## Commands
+
+**Install:**
+```bash
+pip install -r requirements.txt
+pip install .
+```
+
+**Lint/Format:**
+```bash
+ruff check prfm/
+ruff format prfm/
+```
+
+**Pre-commit (lint + format):**
+```bash
+pre-commit run --all-files
+```
+
+**Build documentation (Jupyter Book):**
+```bash
+jupyter-book build book/
+```
+
+**Run tests:**
+```bash
+pytest tests/ -v
+```
+
+## Architecture
+
+### Core computation layer (`prfm/prfm.py`)
+
+Pure functions organized around disk physics:
+
+- **Scale height solvers**: `get_scale_height_gas_only`, `get_scale_height_star_only`, `get_scale_height_dm_only`, `get_scale_height_star_gas`, `get_scale_height_thin`, `get_scale_height_thick`, `get_scale_height_numerical`
+- **Pressure/weight**: `get_weight_gas/star/dm`, `get_pressure`, `get_weights`
+- **Feedback & SFR**: `get_sigma_eff`, `get_feedback_yield`, `get_feedback_yield_comp`, `get_sfr`, `get_self_consistent_solution`
+
+Two embedded model dictionaries drive parameterized behavior:
+- `_sigma_eff_models` — velocity dispersion models (e.g. `tigress-classic-mid`, `tigress-ncr-avg`)
+- `_yield_models` — feedback yield models (e.g. `tigress-classic`, `tigress-ncr-decomp-all`)
+
+### Object-oriented wrapper (`PRFM` class)
+
+`PRFM` in `prfm/prfm.py` wraps the functional layer with:
+- Automatic unit conversion (CGS ↔ astronomical)
+- Multiple disk configurations: thin, thick, general
+- Flexible input modes for stellar (surface or volume density) and dark matter (rotation speed or density)
+- Built-in model management
+
+### Data handling (`prfm/simulations.py`)
+
+`PRFM_data` container for simulation outputs and observational data, with log/linear conversion and uncertainty propagation.
+
+### Bundled data
+
+- `prfm/prfm_ring.csv` — ring model parameters
+- `prfm/tigress_ncr_K24.nc` — TIGRESS-NCR simulation data (Kim et al. 2024)
+- `data/all_data_z0_selected.pkl` — processed galaxy/simulation data used in notebooks
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,3 +87,8 @@ Two embedded model dictionaries drive parameterized behavior:
 - **Type hints**: All Python functions must have type annotations.
 - **Branch workflow**: New development goes on a feature branch; open a WIP PR with a task checklist immediately after planning.
 - **Frequent commits**: Commit after each self-contained chunk of work — do not bundle unrelated changes.
+- **Modular Design**: When writing python scripts, any helper functions should be in a python file such that reusable.
+
+## matplotlib plotting tips
+
+- **fontsize**: never use the absolute value. use medium, small, x-small, etc.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,17 @@ pre-commit run --all-files
 jupyter-book build book/
 ```
 
-**Run tests:**
+**Run tests (unit only, no data required):**
+```bash
+pytest tests/ -v -m "not integration"
+```
+
+**Run a single test file:**
+```bash
+pytest tests/test_prfm.py -v
+```
+
+**Run all tests including integration (requires downloaded PHANGS data):**
 ```bash
 pytest tests/ -v
 ```
@@ -69,3 +79,11 @@ Two embedded model dictionaries drive parameterized behavior:
 - `prfm/tigress_ncr_K24.nc` — TIGRESS-NCR simulation data (Kim et al. 2024)
 - `data/all_data_z0_selected.pkl` — processed galaxy/simulation data used in notebooks
 
+## Development Rules
+
+- **TDD**: Write tests before implementation; unit tests must not require network or disk data.
+- **Plan first**: For any non-trivial feature, enter plan mode and get alignment before coding.
+- **Ask clarifying questions** before starting work when requirements are ambiguous.
+- **Type hints**: All Python functions must have type annotations.
+- **Branch workflow**: New development goes on a feature branch; open a WIP PR with a task checklist immediately after planning.
+- **Frequent commits**: Commit after each self-contained chunk of work — do not bundle unrelated changes.

--- a/book/_config.yml
+++ b/book/_config.yml
@@ -9,6 +9,8 @@ author: Chang-Goo Kim and Eve Ostriker
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: cache
+  exclude_patterns:
+    - 'prfm_phangs.ipynb'   # requires local PHANGS data; uses stored outputs
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/book/api.rst
+++ b/book/api.rst
@@ -27,3 +27,16 @@ PRFM simulation data loader
 ---------------------------
 
 .. autofunction:: prfm.simulations.load_sim_data
+
+PHANGS data utilities
+---------------------
+
+.. autofunction:: prfm.phangs.load
+
+.. autofunction:: prfm.phangs.load_all
+
+.. autofunction:: prfm.phangs.compute_prfm_inputs
+
+.. autofunction:: prfm.phangs.run_prfm
+
+.. autofunction:: prfm.phangs.valid_rows

--- a/book/api.rst
+++ b/book/api.rst
@@ -39,4 +39,6 @@ PHANGS data utilities
 
 .. autofunction:: prfm.phangs.run_prfm
 
+.. autofunction:: prfm.phangs.get_weights
+
 .. autofunction:: prfm.phangs.valid_rows

--- a/prfm/__init__.py
+++ b/prfm/__init__.py
@@ -18,6 +18,7 @@ from prfm.prfm import (
 )
 
 from prfm import simulations
+from prfm import phangs
 
 __all__ = [
     "get_scale_height",
@@ -31,4 +32,5 @@ __all__ = [
     "get_sigma_eff",
     "PRFM",
     "simulations",
+    "phangs",
 ]

--- a/prfm/phangs.py
+++ b/prfm/phangs.py
@@ -1,0 +1,294 @@
+"""
+PHANGS megatable data handling for PRFM theory applications.
+
+Data source: Sun et al. 2022/2023 (v4.0 public release)
+  https://www.canfar.net/storage/vault/list/phangs/RELEASES/Sun_etal_2022
+
+Key references:
+  Sun et al. 2022 — https://ui.adsabs.harvard.edu/abs/2022AJ....164...43S
+  Sun et al. 2023 — https://ui.adsabs.harvard.edu/abs/2023ApJ...945L..19S
+"""
+
+from pathlib import Path
+
+import astropy.units as au
+import numpy as np
+from astropy.table import Table, vstack
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CANFAR_BASE = (
+    "https://ws-cadc.canfar.net/vault/files/phangs/RELEASES"
+    "/Sun_etal_2022/v4p0_public_release"
+)
+
+_VERSION = "v4p0"
+
+# Aperture type → suffix in filename
+_APERTURE_SUFFIX = {
+    "annulus": "annulus_0p5kpc",
+    "gauss": "gauss_1p5kpc",
+    "hexagon": "hexagon_1p5kpc",
+}
+
+# All 90 galaxies in the v4.0 release (alphabetical order)
+_GALAXIES = [
+    "ESO097-013", "IC1954", "IC5273", "IC5332",
+    "NGC0253", "NGC0300", "NGC0628", "NGC0685",
+    "NGC1087", "NGC1097", "NGC1300", "NGC1317", "NGC1365", "NGC1385",
+    "NGC1433", "NGC1511", "NGC1512", "NGC1546", "NGC1559", "NGC1566",
+    "NGC1637", "NGC1792", "NGC1809",
+    "NGC2090", "NGC2283", "NGC2566", "NGC2775", "NGC2835", "NGC2903",
+    "NGC2997",
+    "NGC3059", "NGC3137", "NGC3239", "NGC3351", "NGC3489", "NGC3507",
+    "NGC3511", "NGC3521", "NGC3596", "NGC3599", "NGC3621", "NGC3626",
+    "NGC3627",
+    "NGC4254", "NGC4293", "NGC4298", "NGC4303", "NGC4321", "NGC4457",
+    "NGC4459", "NGC4476", "NGC4477", "NGC4496A", "NGC4535", "NGC4536",
+    "NGC4540", "NGC4548", "NGC4569", "NGC4571", "NGC4596", "NGC4689",
+    "NGC4731", "NGC4781", "NGC4826", "NGC4941", "NGC4951",
+    "NGC5042", "NGC5068", "NGC5128", "NGC5134", "NGC5236", "NGC5248",
+    "NGC5530", "NGC5643",
+    "NGC6300", "NGC6744",
+    "NGC7456", "NGC7496", "NGC7743", "NGC7793",
+]
+
+
+# ---------------------------------------------------------------------------
+# Catalogue helpers
+# ---------------------------------------------------------------------------
+
+
+def list_galaxies():
+    """Return the list of galaxy names in the v4.0 release."""
+    return list(_GALAXIES)
+
+
+def filename(galaxy, aperture="annulus"):
+    """Return the ECSV filename for a given galaxy and aperture type.
+
+    Parameters
+    ----------
+    galaxy : str
+        Galaxy name, e.g. ``"NGC0628"``.
+    aperture : str
+        One of ``"annulus"``, ``"gauss"``, ``"hexagon"``.
+
+    Returns
+    -------
+    str
+    """
+    if aperture not in _APERTURE_SUFFIX:
+        raise ValueError(
+            f"Unknown aperture '{aperture}'. "
+            f"Choose from {list(_APERTURE_SUFFIX)}"
+        )
+    return f"{galaxy}_{_APERTURE_SUFFIX[aperture]}.ecsv"
+
+
+def list_files(aperture=None):
+    """Return all ECSV filenames in the release.
+
+    Parameters
+    ----------
+    aperture : str or None
+        If given, filter to that aperture type
+        (``"annulus"``, ``"gauss"``, or ``"hexagon"``).
+
+    Returns
+    -------
+    list of str
+    """
+    apertures = [aperture] if aperture else list(_APERTURE_SUFFIX)
+    files = []
+    for ap in apertures:
+        for galaxy in _GALAXIES:
+            files.append(filename(galaxy, aperture=ap))
+    return files
+
+
+def build_url(fname):
+    """Return the download URL for a given filename."""
+    return f"{_CANFAR_BASE}/{fname}"
+
+
+# ---------------------------------------------------------------------------
+# Download
+# ---------------------------------------------------------------------------
+
+
+def download(dest_dir, aperture="annulus", galaxies=None, force=False):
+    """Download PHANGS megatable ECSV files to *dest_dir*.
+
+    Parameters
+    ----------
+    dest_dir : str or Path
+        Directory to save files into (created if absent).
+    aperture : str or ``"all"``
+        Aperture type to download, or ``"all"`` for all three types.
+    galaxies : list of str or None
+        Subset of galaxies.  ``None`` downloads all 90.
+    force : bool
+        Re-download even if the file already exists locally.
+
+    Returns
+    -------
+    list of Path
+        Paths of downloaded files.
+    """
+    import urllib.request
+
+    dest_dir = Path(dest_dir)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+
+    apertures = list(_APERTURE_SUFFIX) if aperture == "all" else [aperture]
+    gals = galaxies if galaxies is not None else _GALAXIES
+
+    downloaded = []
+    for ap in apertures:
+        for gal in gals:
+            fname = filename(gal, aperture=ap)
+            dest = dest_dir / fname
+            if dest.exists() and not force:
+                downloaded.append(dest)
+                continue
+            url = build_url(fname)
+            try:
+                urllib.request.urlretrieve(url, dest)
+                downloaded.append(dest)
+            except Exception as exc:
+                print(f"Warning: could not download {fname}: {exc}")
+    return downloaded
+
+
+# ---------------------------------------------------------------------------
+# I/O
+# ---------------------------------------------------------------------------
+
+
+def load(path):
+    """Load a single PHANGS megatable ECSV file.
+
+    Parameters
+    ----------
+    path : str or Path
+
+    Returns
+    -------
+    `~astropy.table.Table`
+        Table with units attached and ``GALAXY`` stored in ``.meta``.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(path)
+    return Table.read(path, format="ascii.ecsv")
+
+
+def load_all(data_dir, aperture="annulus"):
+    """Load and vertically stack all ECSV files in *data_dir*.
+
+    A ``GALAXY`` column is added (taken from table metadata) before stacking.
+
+    Parameters
+    ----------
+    data_dir : str or Path
+    aperture : str
+        Filter to this aperture type.
+
+    Returns
+    -------
+    `~astropy.table.Table`
+    """
+    data_dir = Path(data_dir)
+    pattern = f"*_{_APERTURE_SUFFIX[aperture]}.ecsv"
+    files = sorted(data_dir.glob(pattern))
+    if not files:
+        raise FileNotFoundError(
+            f"No files matching '{pattern}' found in {data_dir}"
+        )
+    tables = []
+    for f in files:
+        t = load(f)
+        galaxy = t.meta.get("GALAXY", f.stem.split("_")[0])
+        t["GALAXY"] = galaxy
+        tables.append(t)
+    return vstack(tables)
+
+
+# ---------------------------------------------------------------------------
+# Derived PRFM quantities
+# ---------------------------------------------------------------------------
+
+
+def compute_prfm_inputs(table):
+    """Add PRFM-relevant derived columns to a megatable.
+
+    Derived columns added
+    ---------------------
+    ``Sigma_gas``
+        Total gas surface density = ``Sigma_mol + Sigma_atom``
+        [M_sun / pc^2].
+    ``Omega_d``
+        Angular velocity = ``V_circ_CO21_URC / r_gal`` [km / s / kpc].
+    ``H_star``
+        Stellar scale height = ``Sigma_star / (2 * rho_star_mp)`` [pc].
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table`
+
+    Returns
+    -------
+    `~astropy.table.Table`
+        A copy of the input table with the new columns appended.
+    """
+    t = table.copy()
+
+    Sigma_mol = t["Sigma_mol"].to(au.M_sun / au.pc**2)
+    Sigma_atom = t["Sigma_atom"].to(au.M_sun / au.pc**2)
+    t["Sigma_gas"] = (Sigma_mol + Sigma_atom).to(au.M_sun / au.pc**2)
+    t["Sigma_gas"].description = "Total gas surface density (mol + atom)"
+
+    V_circ = t["V_circ_CO21_URC"].to(au.km / au.s)
+    r_gal = t["r_gal"].to(au.kpc)
+    t["Omega_d"] = (V_circ / r_gal).to(au.km / au.s / au.kpc)
+    t["Omega_d"].description = "Angular velocity V_circ / r_gal"
+
+    Sigma_star = t["Sigma_star"].to(au.M_sun / au.pc**2)
+    rho_star = t["rho_star_mp"].to(au.M_sun / au.pc**3)
+    t["H_star"] = (Sigma_star / (2.0 * rho_star)).to(au.pc)
+    t["H_star"].description = "Stellar scale height Sigma_star / (2 * rho_star_mp)"
+
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Quality masking
+# ---------------------------------------------------------------------------
+
+
+def valid_rows(table, cols=None):
+    """Boolean mask selecting rows that are finite and positive.
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table`
+    cols : list of str or None
+        Columns to check.  ``None`` checks all numeric columns.
+
+    Returns
+    -------
+    numpy.ndarray of bool
+    """
+    if cols is None:
+        cols = [
+            c for c in table.colnames
+            if table[c].dtype.kind in ("f", "i")
+        ]
+    mask = np.ones(len(table), dtype=bool)
+    for col in cols:
+        vals = np.asarray(table[col], dtype=float)
+        mask &= np.isfinite(vals) & (vals > 0)
+    return mask

--- a/prfm/phangs.py
+++ b/prfm/phangs.py
@@ -9,8 +9,11 @@ Key references:
   Sun et al. 2023 — https://ui.adsabs.harvard.edu/abs/2023ApJ...945L..19S
 """
 
+import warnings
 from pathlib import Path
+from typing import Optional
 
+import astropy.constants as ac
 import astropy.units as au
 import numpy as np
 from astropy.table import Table, vstack
@@ -292,3 +295,124 @@ def valid_rows(table, cols=None):
         vals = np.asarray(table[col], dtype=float)
         mask &= np.isfinite(vals) & (vals > 0)
     return mask
+
+
+# ---------------------------------------------------------------------------
+# PRFM model application
+# ---------------------------------------------------------------------------
+
+# Unit conversion factors (astro → CGS) matching prfm.prfm conventions
+_surf_cgs = (ac.M_sun / ac.pc**2).cgs.value      # M_sun/pc² → g/cm²
+_pc_cgs = ac.pc.cgs.value                          # pc → cm
+_kms_kpc_cgs = 1.0e5 / (3.085677581e21)            # km/s/kpc → 1/s
+_kbol_cgs = ac.k_B.cgs.value                       # erg/K
+_sfr_cgs = (ac.M_sun / ac.kpc**2 / au.yr).cgs.value  # M_sun/kpc²/yr → g/cm²/s
+
+
+def run_prfm(
+    table: Table,
+    sigma_eff_model: str = "tigress-ncr-avg",
+    yield_model: str = "tigress-ncr-decomp-all",
+    zprime_col: Optional[str] = "Zprime",
+) -> Table:
+    """Apply the PRFM model to every row of a PHANGS megatable.
+
+    Runs :func:`compute_prfm_inputs` if ``Sigma_gas`` is not already present,
+    then calls the self-consistent PRFM solver (vectorized over all rows).
+    Invalid rows (NaN or non-positive PRFM inputs) receive ``NaN`` outputs.
+
+    Columns added
+    -------------
+    ``P_weight``
+        Dynamical equilibrium pressure (total gas weight)
+        in units of :math:`k_\\mathrm{B}` K cm\\ :sup:`-3`.
+    ``H_gas``
+        Self-consistent gas scale height [pc].
+    ``sigma_eff_sol``
+        Self-consistent effective velocity dispersion [km s\\ :sup:`-1`].
+    ``Sigma_SFR_pred``
+        Predicted SFR surface density [M_sun kpc\\ :sup:`-2` yr\\ :sup:`-1`].
+
+    Parameters
+    ----------
+    table : `~astropy.table.Table`
+        PHANGS megatable, optionally pre-processed by :func:`compute_prfm_inputs`.
+    sigma_eff_model : str
+        Velocity dispersion model name (key in ``prfm._sigma_eff_models``).
+    yield_model : str
+        Feedback yield model name (key in ``prfm._yield_models``).
+    zprime_col : str or None
+        Column name for metallicity (relative to solar).  Pass ``None`` to
+        ignore metallicity dependence.
+
+    Returns
+    -------
+    `~astropy.table.Table`
+        Copy of the input table with four new columns appended.
+    """
+    from prfm.prfm import get_self_consistent_solution, get_sfr
+
+    t = table.copy()
+
+    # Ensure derived PRFM inputs exist
+    if "Sigma_gas" not in t.colnames:
+        t = compute_prfm_inputs(t)
+
+    # Identify valid rows
+    prfm_cols = ["Sigma_gas", "Sigma_star", "Omega_d", "H_star"]
+    mask = valid_rows(t, cols=prfm_cols)
+    n_invalid = (~mask).sum()
+    if n_invalid > 0:
+        warnings.warn(
+            f"run_prfm: {n_invalid} row(s) with invalid PRFM inputs will be NaN.",
+            stacklevel=2,
+        )
+
+    # Initialise output arrays with NaN
+    n = len(t)
+    P_weight = np.full(n, np.nan)
+    H_gas = np.full(n, np.nan)
+    sigma_sol = np.full(n, np.nan)
+    Sigma_SFR_pred = np.full(n, np.nan)
+
+    if mask.any():
+        # Extract valid rows and convert to CGS
+        sg = np.asarray(t["Sigma_gas"][mask], dtype=float) * _surf_cgs
+        ss = np.asarray(t["Sigma_star"][mask], dtype=float) * _surf_cgs
+        od = np.asarray(t["Omega_d"][mask], dtype=float) * _kms_kpc_cgs
+        hs = np.asarray(t["H_star"][mask], dtype=float) * _pc_cgs
+
+        # Metallicity (dimensionless relative to solar); default to solar (Z=1) if absent
+        if zprime_col is not None and zprime_col in t.colnames:
+            Z: np.ndarray = np.asarray(t[zprime_col][mask], dtype=float)
+        else:
+            Z = np.ones(int(mask.sum()))
+
+        # Solve
+        wtot, H_cgs, se_cgs = get_self_consistent_solution(
+            sg, ss, od, hs, sigma_eff=sigma_eff_model
+        )
+
+        # Back-convert to observer-friendly units
+        P_weight[mask] = wtot / _kbol_cgs          # k_B K cm^-3
+        H_gas[mask] = H_cgs / _pc_cgs              # pc
+        sigma_sol[mask] = se_cgs / 1.0e5           # km/s
+
+        # Predicted SFR
+        sfr_cgs = get_sfr(wtot, Z=Z, Ytot=yield_model)
+        Sigma_SFR_pred[mask] = sfr_cgs / _sfr_cgs  # M_sun/kpc²/yr
+
+    # Attach columns with astropy units
+    t["P_weight"] = P_weight * au.K / au.cm**3
+    t["P_weight"].description = "Dynamical equilibrium pressure (P_DE / k_B)"
+
+    t["H_gas"] = H_gas * au.pc
+    t["H_gas"].description = "Self-consistent gas scale height"
+
+    t["sigma_eff_sol"] = sigma_sol * au.km / au.s
+    t["sigma_eff_sol"].description = "Self-consistent effective velocity dispersion"
+
+    t["Sigma_SFR_pred"] = Sigma_SFR_pred * au.M_sun / au.kpc**2 / au.yr
+    t["Sigma_SFR_pred"].description = "PRFM-predicted SFR surface density"
+
+    return t

--- a/prfm/phangs.py
+++ b/prfm/phangs.py
@@ -17,7 +17,6 @@ import astropy.constants as ac
 import astropy.units as au
 import numpy as np
 from astropy.table import Table, vstack
-import prfm
 
 # ---------------------------------------------------------------------------
 # Constants

--- a/prfm/phangs.py
+++ b/prfm/phangs.py
@@ -211,13 +211,19 @@ def load_all(data_dir, aperture="annulus"):
         raise FileNotFoundError(
             f"No files matching '{pattern}' found in {data_dir}"
         )
-    tables = []
+    tables = dict()
     for f in files:
         t = load(f)
         galaxy = t.meta.get("GALAXY", f.stem.split("_")[0])
+        tables[galaxy] = t
+    return tables
+
+def vstack_tables(tables):
+    tbl = []
+    for galaxy, t in tables.items():
         t["GALAXY"] = galaxy
-        tables.append(t)
-    return vstack(tables, metadata_conflicts="silent")
+        tbl.append(t)
+    return vstack(tbl, metadata_conflicts="silent")
 
 
 # ---------------------------------------------------------------------------
@@ -233,6 +239,10 @@ def compute_prfm_inputs(table):
     ``Sigma_gas``
         Total gas surface density = ``Sigma_mol + Sigma_atom``
         [M_sun / pc^2].
+    ``e_Sigma_gas``
+        Uncertainty on ``Sigma_gas`` = ``sqrt(e_Sigma_mol^2 + e_Sigma_atom^2)``
+        [M_sun / pc^2].  Added only when both ``e_Sigma_mol`` and
+        ``e_Sigma_atom`` are present.
     ``Omega_d``
         Angular velocity = ``V_circ_CO21_URC / r_gal`` [km / s / kpc].
     ``H_star``
@@ -253,6 +263,12 @@ def compute_prfm_inputs(table):
     Sigma_atom = t["Sigma_atom"].to(au.M_sun / au.pc**2)
     t["Sigma_gas"] = (Sigma_mol + Sigma_atom).to(au.M_sun / au.pc**2)
     t["Sigma_gas"].description = "Total gas surface density (mol + atom)"
+
+    if "e_Sigma_mol" in t.colnames and "e_Sigma_atom" in t.colnames:
+        e_mol = t["e_Sigma_mol"].to(au.M_sun / au.pc**2)
+        e_atom = t["e_Sigma_atom"].to(au.M_sun / au.pc**2)
+        t["e_Sigma_gas"] = np.sqrt(e_mol**2 + e_atom**2).to(au.M_sun / au.pc**2)
+        t["e_Sigma_gas"].description = "Uncertainty on Sigma_gas (quadrature sum)"
 
     V_circ = t["V_circ_CO21_URC"].to(au.km / au.s)
     r_gal = t["r_gal"].to(au.kpc)

--- a/prfm/phangs.py
+++ b/prfm/phangs.py
@@ -217,7 +217,7 @@ def load_all(data_dir, aperture="annulus"):
         galaxy = t.meta.get("GALAXY", f.stem.split("_")[0])
         t["GALAXY"] = galaxy
         tables.append(t)
-    return vstack(tables)
+    return vstack(tables, metadata_conflicts="silent")
 
 
 # ---------------------------------------------------------------------------

--- a/prfm/phangs.py
+++ b/prfm/phangs.py
@@ -17,6 +17,7 @@ import astropy.constants as ac
 import astropy.units as au
 import numpy as np
 from astropy.table import Table, vstack
+import prfm
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -259,15 +260,28 @@ def compute_prfm_inputs(table):
     """
     t = table.copy()
 
-    Sigma_mol = t["Sigma_mol"].to(au.M_sun / au.pc**2)
-    Sigma_atom = t["Sigma_atom"].to(au.M_sun / au.pc**2)
-    t["Sigma_gas"] = (Sigma_mol + Sigma_atom).to(au.M_sun / au.pc**2)
-    t["Sigma_gas"].description = "Total gas surface density (mol + atom)"
+    Sigma_mol  = np.asarray(t["Sigma_mol"].to(au.M_sun / au.pc**2))
+    Sigma_atom = np.asarray(t["Sigma_atom"].to(au.M_sun / au.pc**2))
+
+    # Treat non-detections as zero for each component, but only when the other
+    # component is detected.  If both are NaN the sum stays NaN.
+    either_valid = np.isfinite(Sigma_mol) | np.isfinite(Sigma_atom)
+    mol_filled  = np.where(np.isfinite(Sigma_mol),  Sigma_mol,  0.0)
+    atom_filled = np.where(np.isfinite(Sigma_atom), Sigma_atom, 0.0)
+    Sigma_gas = np.where(either_valid, mol_filled + atom_filled, np.nan)
+    t["Sigma_gas"] = Sigma_gas * au.M_sun / au.pc**2
+    t["Sigma_gas"].description = (
+        "Total gas surface density (mol + atom; non-detections filled with 0)"
+    )
 
     if "e_Sigma_mol" in t.colnames and "e_Sigma_atom" in t.colnames:
-        e_mol = t["e_Sigma_mol"].to(au.M_sun / au.pc**2)
-        e_atom = t["e_Sigma_atom"].to(au.M_sun / au.pc**2)
-        t["e_Sigma_gas"] = np.sqrt(e_mol**2 + e_atom**2).to(au.M_sun / au.pc**2)
+        e_mol  = np.asarray(t["e_Sigma_mol"].to(au.M_sun / au.pc**2))
+        e_atom = np.asarray(t["e_Sigma_atom"].to(au.M_sun / au.pc**2))
+        # propagate only the errors that exist; treat missing component error as 0
+        e_mol_filled  = np.where(np.isfinite(e_mol),  e_mol,  0.0)
+        e_atom_filled = np.where(np.isfinite(e_atom), e_atom, 0.0)
+        e_gas = np.where(either_valid, np.sqrt(e_mol_filled**2 + e_atom_filled**2), np.nan)
+        t["e_Sigma_gas"] = e_gas * au.M_sun / au.pc**2
         t["e_Sigma_gas"].description = "Uncertainty on Sigma_gas (quadrature sum)"
 
     V_circ = t["V_circ_CO21_URC"].to(au.km / au.s)
@@ -288,7 +302,7 @@ def compute_prfm_inputs(table):
 # ---------------------------------------------------------------------------
 
 
-def valid_rows(table, cols=None):
+def valid_rows(table, cols=None, rel_error=0.1):
     """Boolean mask selecting rows that are finite and positive.
 
     Parameters
@@ -310,6 +324,9 @@ def valid_rows(table, cols=None):
     for col in cols:
         vals = np.asarray(table[col], dtype=float)
         mask &= np.isfinite(vals) & (vals > 0)
+        if (rel_error>0) and (f"e_{col}" in table.colnames):
+            e_vals = np.asarray(table["e_"+col], dtype=float)
+            mask &= np.isfinite(e_vals) & (e_vals/vals < rel_error)
     return mask
 
 
@@ -327,9 +344,11 @@ _sfr_cgs = (ac.M_sun / ac.kpc**2 / au.yr).cgs.value  # M_sun/kpc²/yr → g/cm²
 
 def run_prfm(
     table: Table,
+    prfm_cols: Optional[str] = ["Sigma_gas", "Sigma_star", "Omega_d", "H_star"],
     sigma_eff_model: str = "tigress-ncr-avg",
     yield_model: str = "tigress-ncr-decomp-all",
     zprime_col: Optional[str] = "Zprime",
+    variation: Optional[dict] = None,
 ) -> Table:
     """Apply the PRFM model to every row of a PHANGS megatable.
 
@@ -375,7 +394,6 @@ def run_prfm(
         t = compute_prfm_inputs(t)
 
     # Identify valid rows
-    prfm_cols = ["Sigma_gas", "Sigma_star", "Omega_d", "H_star"]
     mask = valid_rows(t, cols=prfm_cols)
     n_invalid = (~mask).sum()
     if n_invalid > 0:
@@ -390,13 +408,32 @@ def run_prfm(
     H_gas = np.full(n, np.nan)
     sigma_sol = np.full(n, np.nan)
     Sigma_SFR_pred = np.full(n, np.nan)
-
+    print(mask.sum(), "valid rows out of", n)
     if mask.any():
         # Extract valid rows and convert to CGS
         sg = np.asarray(t["Sigma_gas"][mask], dtype=float) * _surf_cgs
         ss = np.asarray(t["Sigma_star"][mask], dtype=float) * _surf_cgs
-        od = np.asarray(t["Omega_d"][mask], dtype=float) * _kms_kpc_cgs
+        if "Omega_d" in prfm_cols:
+            od = np.asarray(t["Omega_d"][mask], dtype=float) * _kms_kpc_cgs
+        else:
+            od = None
         hs = np.asarray(t["H_star"][mask], dtype=float) * _pc_cgs
+
+        if variation is not None:
+            if "Omega_d" in variation:
+                print("Applying variation: setting Omega_d to", variation["Omega_d"])
+                if variation["Omega_d"] is None:
+                    od = None
+                else:
+                    od *= variation["Omega_d"]
+
+            if "Sigma_star" in variation:
+                print("Applying variation: scaling Sigma_star by", variation["Sigma_star"])
+                ss *= variation["Sigma_star"]
+
+            if "H_star" in variation:
+                print("Applying variation: scaling H_star by", variation["H_star"])
+                hs *= variation["H_star"]
 
         # Metallicity (dimensionless relative to solar); default to solar (Z=1) if absent
         if zprime_col is not None and zprime_col in t.colnames:
@@ -432,3 +469,34 @@ def run_prfm(
     t["Sigma_SFR_pred"].description = "PRFM-predicted SFR surface density"
 
     return t
+
+# Convert inputs to CGS for get_weight_contribution
+def get_weights(table: Table,
+                variation: Optional[dict] = None
+                ) -> (np.ndarray, np.ndarray, np.ndarray):
+    from prfm.prfm import get_weight_contribution
+
+    sg  = np.asarray(table["Sigma_gas"],    dtype=float) * _surf_cgs
+    ss  = np.asarray(table["Sigma_star"],   dtype=float) * _surf_cgs
+    od  = np.asarray(table["Omega_d"],      dtype=float) * _kms_kpc_cgs
+    hs  = np.asarray(table["H_star"],       dtype=float) * _pc_cgs
+    se  = np.asarray(table["sigma_eff_sol"],dtype=float) * 1e5   # km/s → cm/s
+
+    if variation is not None:
+        if "Omega_d" in variation:
+            print("Applying variation: setting Omega_d to", variation["Omega_d"])
+            if variation["Omega_d"] is None:
+                od = None
+            else:
+                od *= variation["Omega_d"]
+
+        if "Sigma_star" in variation:
+            print("Applying variation: scaling Sigma_star by", variation["Sigma_star"])
+            ss *= variation["Sigma_star"]
+
+        if "H_star" in variation:
+            print("Applying variation: scaling H_star by", variation["H_star"])
+            hs *= variation["H_star"]
+
+    f_gas, f_star, f_dm = get_weight_contribution(sg, ss, od, hs, se)
+    return f_gas, f_star, f_dm

--- a/prfm/phangs_plot.py
+++ b/prfm/phangs_plot.py
@@ -392,8 +392,8 @@ def scatter_plot(
             return
         xm, ym = x[mask], y[mask]
         if ex is not None or ey is not None:
-            xerr = None if ex is None else _asymmetric_errorbars(xm, ex[mask])
-            yerr = None if ey is None else _asymmetric_errorbars(ym, ey[mask])
+            xerr = None if ex is None else get_symmetric_log_errorbars(xm, ex[mask])
+            yerr = None if ey is None else get_symmetric_log_errorbars(ym, ey[mask])
             ax.errorbar(
                 xm, ym,
                 xerr=xerr, yerr=yerr,
@@ -604,3 +604,82 @@ def _parse_slices(
             results.append((mask, color, label))
         break  # one slice column supported
     return results
+
+def get_symmetric_log_errorbars(linear_mean, linear_std):
+    """
+    Approximates linear standard deviation into a multiplicative factor so that
+    the resulting error bars appear visually symmetric on a log-scaled axis.
+
+    Parameters:
+    -----------
+    linear_mean : array_like
+        The mean values calculated in linear space.
+    linear_std : array_like
+        The standard deviation values calculated in linear space.
+
+    Returns:
+    --------
+    asymmetric_error : list of numpy.ndarray
+        A 2-element list [lower_errors, upper_errors] containing the absolute
+        linear distances required by Matplotlib's `yerr`.
+    """
+    linear_mean = np.asarray(linear_mean, dtype=float)
+    linear_std = np.asarray(linear_std, dtype=float)
+
+    # 1. Calculate the Coefficient of Variation (fractional error)
+    cv = linear_std / linear_mean
+
+    # 2. Calculate the multiplicative factor
+    # Using np.exp ensures the math works perfectly regardless of the log base
+    # Matplotlib uses for its axis scaling.
+    multiplier = np.exp(cv)
+
+    # 3. Calculate the new bounds based on the multiplier
+    upper_bound = linear_mean * multiplier
+    lower_bound = linear_mean / multiplier
+
+    # 4. Calculate the distances from the center point for Matplotlib
+    yerr_lower = linear_mean - lower_bound
+    yerr_upper = upper_bound - linear_mean
+
+    return [yerr_lower, yerr_upper]
+
+# Convert inputs to CGS for get_weight_contribution
+def plot_weights(tbl, ax=None, variation=None):
+    from prfm.phangs import get_weights
+
+    f_gas, f_star, f_dm = get_weights(tbl, variation=variation)
+    P_DE = np.asarray(tbl["P_weight"], dtype=float)   # k_B K cm^-3
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=(5, 3.5))
+    else:
+        fig = ax.figure
+    kw = dict(s=2, alpha=0.5, rasterized=True, linewidths=0)
+    ax.scatter(P_DE, f_gas,  color="tab:blue",   **kw)
+    ax.scatter(P_DE, f_star, color="tab:orange", **kw)
+    ax.scatter(P_DE, f_dm,   color="tab:green",  **kw)
+
+    # Binned means
+    P_edges = np.logspace(np.log10(np.nanpercentile(P_DE, 1)),
+                        np.log10(np.nanpercentile(P_DE, 99)), 20)
+    P_centers = np.sqrt(P_edges[:-1] * P_edges[1:])   # geometric mid-points
+    for f, color, label in [
+        (f_gas,  "tab:blue",   r"$f_\mathrm{gas}$"),
+        (f_star, "tab:orange", r"$f_\star$"),
+        (f_dm,   "tab:green",  r"$f_\mathrm{DM}$"),
+    ]:
+        means = [np.nanmean(f[(P_DE >= lo) & (P_DE < hi)])
+                for lo, hi in zip(P_edges[:-1], P_edges[1:])]
+        ax.plot(P_centers, means, color=color, lw=2, label=label)
+
+    n_valid = np.isfinite(P_DE).sum()
+    ax.set_xscale("log")
+    ax.set_xlabel(r"$P_\mathrm{DE}/k_B\ [\mathrm{K\,cm^{-3}}]$")
+    ax.set_ylabel(r"$\mathcal{W}_i\,/\,\mathcal{W}_\mathrm{tot}$")
+    ax.set_ylim(0, 1)
+    ax.legend(markerscale=5)
+    ax.annotate(f"N={n_valid}", xy=(0.97, 0.97), xycoords="axes fraction",
+                ha="right", va="top", fontsize="x-small", color="0.4")
+    fig.tight_layout()
+    return fig

--- a/prfm/phangs_plot.py
+++ b/prfm/phangs_plot.py
@@ -1,0 +1,606 @@
+"""
+Shared plotting and data-preparation utilities for PHANGS megatable exploration.
+
+Imported by scripts that produce exploratory figures; not part of the public
+PRFM computation API.
+"""
+
+from collections.abc import Sequence
+from typing import Any, Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+from astropy.table import Table
+
+# ---------------------------------------------------------------------------
+# Aperture configuration
+# ---------------------------------------------------------------------------
+
+# Aperture type → column-name suffix used in the megatable
+APERTURE_SUFFIX: dict[str, str] = {
+    "annulus": "",
+    "gauss": "_gauss",
+    "hexagon": "_hexagon",
+}
+
+# Columns that never carry an aperture suffix (shared across all apertures)
+NO_SUFFIX: set[str] = {
+    "r_gal",
+    "Zprime",
+    "alpha_CO21_S20",
+    "rho_star_mp",
+    "V_circ_CO21_URC",
+    "Omega_d",
+    "H_star",
+    "Sigma_gas",  # derived by compute_prfm_inputs
+}
+
+# ---------------------------------------------------------------------------
+# Column label registry  (base name → LaTeX label with units)
+# ---------------------------------------------------------------------------
+
+COLUMN_LABELS: dict[str, str] = {
+    "r_gal":               r"$r_\mathrm{gal}$ [kpc]",
+    "Sigma_mol":           r"$\Sigma_\mathrm{mol}$ [$M_\odot\,\mathrm{pc}^{-2}$]",
+    "Sigma_atom":          r"$\Sigma_\mathrm{atom}$ [$M_\odot\,\mathrm{pc}^{-2}$]",
+    "Sigma_gas":           r"$\Sigma_\mathrm{gas}$ [$M_\odot\,\mathrm{pc}^{-2}$]",
+    "Sigma_star":          r"$\Sigma_\star$ [$M_\odot\,\mathrm{pc}^{-2}$]",
+    "rho_star_mp":         r"$\rho_\star$ [$M_\odot\,\mathrm{pc}^{-3}$]",
+    "H_star":              r"$H_\star$ [pc]",
+    "V_circ_CO21_URC":     r"$V_\mathrm{circ}$ [km s$^{-1}$]",
+    "Omega_d":             r"$\Omega_d$ [km s$^{-1}$ kpc$^{-1}$]",
+    "Zprime":              r"$Z'$ [$Z_\odot$]",
+    "Sigma_SFR_HaW4recal": r"$\Sigma_\mathrm{SFR}^\mathrm{H\alpha+W4}$"
+                           r" [$M_\odot\,\mathrm{yr}^{-1}\,\mathrm{kpc}^{-2}$]",
+    "Sigma_SFR_FUVW4recal":r"$\Sigma_\mathrm{SFR}^\mathrm{FUV+W4}$"
+                           r" [$M_\odot\,\mathrm{yr}^{-1}\,\mathrm{kpc}^{-2}$]",
+    "Sigma_SFR_Hacorr":    r"$\Sigma_\mathrm{SFR}^\mathrm{H\alpha,corr}$"
+                           r" [$M_\odot\,\mathrm{yr}^{-1}\,\mathrm{kpc}^{-2}$]",
+    "alpha_CO21_S20":      r"$\alpha_\mathrm{CO}$ [$M_\odot\,\mathrm{pc}^{-2}\,(\mathrm{K\,km\,s}^{-1})^{-1}$]",
+    "P_weight":            r"$P_\mathrm{DE}/k_B$ [K cm$^{-3}$]",
+    "H_gas":               r"$H_\mathrm{gas}$ [pc]",
+    "sigma_eff_sol":       r"$\sigma_\mathrm{eff}$ [km s$^{-1}$]",
+    "Sigma_SFR_pred":      r"$\Sigma_\mathrm{SFR}^\mathrm{pred}$"
+                           r" [$M_\odot\,\mathrm{yr}^{-1}\,\mathrm{kpc}^{-2}$]",
+}
+
+
+def col_label(col: str) -> str:
+    """Return a LaTeX label for *col*, stripping aperture suffix if needed."""
+    if col in COLUMN_LABELS:
+        return COLUMN_LABELS[col]
+    # Strip known aperture suffixes and try again
+    for sfx in ("_gauss", "_hexagon"):
+        if col.endswith(sfx):
+            base = col[: -len(sfx)]
+            if base in COLUMN_LABELS:
+                return COLUMN_LABELS[base]
+    return col
+
+
+# ---------------------------------------------------------------------------
+# Radial bin configuration
+# ---------------------------------------------------------------------------
+
+RGAL_BINS: list[tuple[float, float]] = [(0, 2), (2, 5), (5, 10), (10, 999)]
+RGAL_LABELS: list[str] = [
+    r"$r<2$ kpc",
+    r"$2-5$ kpc",
+    r"$5-10$ kpc",
+    r"$r>10$ kpc",
+]
+RGAL_COLORS: list[str] = ["#c0392b", "#e67e22", "#27ae60", "#2980b9"]
+
+# ---------------------------------------------------------------------------
+# Column-resolution helper
+# ---------------------------------------------------------------------------
+
+
+def resolve_columns(
+    base_fields: list[tuple[str, str, bool]],
+    table: Table,
+    aperture: str = "annulus",
+) -> list[tuple[str, str, bool]]:
+    """Resolve base column names to actual names present in *table*.
+
+    For each ``(base_name, label, log_scale)`` entry, the suffix for the
+    given *aperture* is appended unless the base name is in :data:`NO_SUFFIX`.
+    If the suffixed name is absent, falls back to the unsuffixed name.
+    Entries whose resolved name is absent from *table* are dropped.
+
+    Parameters
+    ----------
+    base_fields:
+        List of ``(base_name, axis_label, log_scale)`` tuples.
+    table:
+        Loaded PHANGS megatable (e.g. from :func:`prfm.phangs.load_all`).
+    aperture:
+        One of ``"annulus"``, ``"gauss"``, ``"hexagon"``.
+
+    Returns
+    -------
+    list of (col_name, label, log_scale) with concrete column names.
+    """
+    sfx = APERTURE_SUFFIX[aperture]
+    resolved: list[tuple[str, str, bool]] = []
+    for base, label, log in base_fields:
+        col = base if base in NO_SUFFIX else base + sfx
+        if col in table.colnames:
+            resolved.append((col, label, log))
+        elif base in table.colnames:
+            resolved.append((base, label, log))
+    return resolved
+
+
+# ---------------------------------------------------------------------------
+# Array helpers
+# ---------------------------------------------------------------------------
+
+
+def to_log_or_raw(
+    table: Table,
+    col: str,
+    log: bool,
+) -> np.ndarray:
+    """Return column values, optionally log10-transformed.
+
+    Non-positive values are mapped to ``NaN`` before taking the logarithm.
+
+    Parameters
+    ----------
+    table:
+        Astropy table containing *col*.
+    col:
+        Column name.
+    log:
+        If ``True``, return ``log10(values)``; otherwise return raw values.
+
+    Returns
+    -------
+    1-D float array of length ``len(table)``.
+    """
+    v = np.asarray(table[col], dtype=float)
+    if log:
+        with np.errstate(divide="ignore", invalid="ignore"):
+            v = np.log10(np.where(v > 0, v, np.nan))
+    return v
+
+
+def build_matrix(
+    table: Table,
+    cols: list[tuple[str, str, bool]],
+) -> tuple[np.ndarray, list[str]]:
+    """Build a 2-D data array restricted to rows that are finite in all columns.
+
+    Parameters
+    ----------
+    table:
+        Astropy table.
+    cols:
+        List of ``(col_name, label, log_scale)`` tuples.
+
+    Returns
+    -------
+    data : ndarray of shape ``(N_valid, len(cols))``
+    labels : list of axis label strings
+    """
+    arrays = [to_log_or_raw(table, col, log) for col, _, log in cols]
+    stacked = np.column_stack(arrays)
+    valid = np.all(np.isfinite(stacked), axis=1)
+    labels = [lbl for _, lbl, _ in cols]
+    return stacked[valid], labels
+
+
+def clean(vals: np.ndarray, log: bool) -> np.ndarray:
+    """Return finite (and positive when *log* is ``True``) values.
+
+    Parameters
+    ----------
+    vals:
+        Input array (will be cast to ``float``).
+    log:
+        If ``True``, also require ``vals > 0``.
+
+    Returns
+    -------
+    1-D float array of valid values.
+    """
+    v = np.asarray(vals, dtype=float)
+    mask = np.isfinite(v)
+    if log:
+        mask &= v > 0
+    return v[mask]
+
+
+def bin_edges(
+    vals: np.ndarray,
+    log: bool,
+    n: int = 40,
+) -> np.ndarray:
+    """Compute histogram bin edges for *vals*.
+
+    Parameters
+    ----------
+    vals:
+        Array of finite values (no NaNs expected).
+    log:
+        If ``True``, produce logarithmically spaced edges.
+    n:
+        Number of bins.
+
+    Returns
+    -------
+    1-D array of ``n + 1`` bin edges.
+    """
+    if log:
+        return np.logspace(np.log10(vals.min()), np.log10(vals.max()), n + 1)
+    return np.linspace(vals.min(), vals.max(), n + 1)
+
+
+# ---------------------------------------------------------------------------
+# Scatter plot
+# ---------------------------------------------------------------------------
+
+
+def _asymmetric_errorbars(
+    vals: np.ndarray,
+    errs: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Convert symmetric errors to asymmetric (lo, hi) pairs for log-safe plotting.
+
+    Clips the lower bar so it never reaches or crosses zero.
+
+    Parameters
+    ----------
+    vals:
+        Central values (positive, finite).
+    errs:
+        Symmetric 1-sigma uncertainties (same units as *vals*).
+
+    Returns
+    -------
+    (err_lo, err_hi) each of the same shape as *vals*.
+    """
+    err_hi = errs.copy()
+    err_lo = np.minimum(errs, vals * 0.9999)  # clip so lower bar stays positive
+    return err_lo, err_hi
+
+
+def _axis_limits(
+    vals: np.ndarray,
+    log: bool,
+    plo: float = 1.0,
+    phi: float = 99.0,
+    margin: float = 0.5,
+) -> tuple[float, float]:
+    """Compute tight axis limits from the *plo*–*phi* percentile range of *vals*.
+
+    Parameters
+    ----------
+    vals:
+        Finite, positive data values.
+    log:
+        If ``True``, apply margin in log10 space.
+    plo, phi:
+        Lower and upper percentile bounds (default 1st–99th).
+    margin:
+        Fractional padding beyond the percentile range.
+        In log space this is in dex; in linear space it is a fraction of the
+        total range.
+
+    Returns
+    -------
+    (lo, hi) axis limit pair.
+    """
+    v = vals[np.isfinite(vals) & (vals > 0)]
+    if len(v) == 0:
+        return (None, None)  # type: ignore[return-value]
+    lo, hi = np.nanpercentile(v, [plo, phi])
+    if log:
+        log_lo = np.log10(lo) - margin
+        log_hi = np.log10(hi) + margin
+        return 10**log_lo, 10**log_hi
+    span = hi - lo
+    return lo - margin * span, hi + margin * span
+
+
+def scatter_plot(
+    table: Table,
+    xcol: str,
+    ycol: str,
+    ax: Optional[plt.Axes] = None,
+    log_x: bool = True,
+    log_y: bool = True,
+    errorbars: bool = True,
+    bg_color: str = "0.6",
+    sel_color: str = "tab:blue",
+    slice_frac: float = 0.1,
+    bg_alpha: float = 0.15,
+    sel_alpha: float = 0.7,
+    s: float = 4,
+    **slice_kwargs: Union[float, Sequence[float]],
+) -> plt.Axes:
+    """Scatter plot of *ycol* vs *xcol* with optional error bars and slice highlighting.
+
+    Parameters
+    ----------
+    table:
+        PHANGS megatable (astropy Table).
+    xcol:
+        Column name for the x-axis.
+    ycol:
+        Column name for the y-axis.
+    ax:
+        Axes to draw on.  A new figure/axes is created if ``None``.
+    log_x:
+        Use log scale on x-axis.
+    log_y:
+        Use log scale on y-axis.
+    errorbars:
+        Draw error bars when ``e_<col>`` columns are present.
+    bg_color:
+        Colour for unselected (background) points.
+    sel_color:
+        Colour for points in the highlighted slice.
+    slice_frac:
+        Half-width of the slice as a fraction of the slice value.
+        E.g. ``slice_frac=0.1`` with ``Sigma_gas=10`` selects rows
+        where ``9 <= Sigma_gas <= 11``.
+    bg_alpha:
+        Alpha for background points.
+    sel_alpha:
+        Alpha for highlighted points.
+    s:
+        Marker size.
+    **slice_kwargs:
+        One optional keyword of the form ``column_name=value`` (scalar) or
+        ``column_name=[v1, v2, ...]`` (multiple values) to highlight one or
+        more narrow slices.  Example::
+
+            scatter_plot(t, "Sigma_gas", "Sigma_SFR_HaW4recal", Sigma_gas=10)
+            scatter_plot(t, "Sigma_gas", "Sigma_SFR_HaW4recal", Sigma_gas=[10, 30])
+
+    Returns
+    -------
+    `~matplotlib.axes.Axes`
+    """
+    if ax is None:
+        _, ax = plt.subplots()
+
+    x = np.asarray(table[xcol], dtype=float)
+    y = np.asarray(table[ycol], dtype=float)
+    valid = np.isfinite(x) & np.isfinite(y) & (x > 0) & (y > 0)
+
+    slices = _parse_slices(table, valid, slice_kwargs, slice_frac, sel_color)
+    any_sel = np.zeros(len(table), dtype=bool)
+    for mask, _, _ in slices:
+        any_sel |= mask
+    bg_mask = valid & ~any_sel
+
+    # Error arrays (None if column absent or errorbars disabled)
+    def _errs(col: str) -> Optional[np.ndarray]:
+        ecol = f"e_{col}"
+        if errorbars and ecol in table.colnames:
+            return np.asarray(table[ecol], dtype=float)
+        return None
+
+    ex = _errs(xcol)
+    ey = _errs(ycol)
+
+    def _plot_group(mask: np.ndarray, color: Any, alpha: float, zorder: int) -> None:
+        if not mask.any():
+            return
+        xm, ym = x[mask], y[mask]
+        if ex is not None or ey is not None:
+            xerr = None if ex is None else _asymmetric_errorbars(xm, ex[mask])
+            yerr = None if ey is None else _asymmetric_errorbars(ym, ey[mask])
+            ax.errorbar(
+                xm, ym,
+                xerr=xerr, yerr=yerr,
+                fmt="o", ms=np.sqrt(s), color=color, alpha=alpha,
+                elinewidth=0.5, capsize=0, zorder=zorder, rasterized=True,
+            )
+        else:
+            ax.scatter(xm, ym, s=s, color=color, alpha=alpha,
+                       zorder=zorder, rasterized=True, linewidths=0)
+
+    if log_x:
+        ax.set_xscale("log")
+    if log_y:
+        ax.set_yscale("log")
+
+    _plot_group(bg_mask, bg_color, bg_alpha, zorder=1)
+    for i, (mask, color, _) in enumerate(slices):
+        _plot_group(mask, color, sel_alpha, zorder=2 + i)
+
+    # Tighten limits based on the data distribution, not the error bars
+    xlim = _axis_limits(x[valid], log=log_x)
+    ylim = _axis_limits(y[valid], log=log_y)
+    if xlim[0] is not None:
+        ax.set_xlim(xlim)
+    if ylim[0] is not None:
+        ax.set_ylim(ylim)
+
+    ax.set_xlabel(col_label(xcol))
+    ax.set_ylabel(col_label(ycol))
+
+    return ax
+
+
+def _pdf_step(
+    vals: np.ndarray,
+    edges: np.ndarray,
+    total: int,
+    log: bool = False,
+) -> np.ndarray:
+    """Compute PDF as count / total / delta_bin for each bin.
+
+    Parameters
+    ----------
+    vals:
+        Data values to histogram (finite, already filtered).
+    edges:
+        Bin edges (length n_bins + 1).
+    total:
+        Total count used for normalisation (typically the full-sample size).
+    log:
+        If ``True``, compute bin widths in log10 space so the PDF integrates
+        to 1 when the x-axis is logarithmic.
+
+    Returns
+    -------
+    pdf : ndarray of length n_bins
+    """
+    counts, _ = np.histogram(vals, bins=edges)
+    if log:
+        delta = np.log10(edges[1:]) - np.log10(edges[:-1])
+    else:
+        delta = edges[1:] - edges[:-1]
+    return counts / total / delta
+
+
+def hist_plot(
+    table: Table,
+    col: str,
+    ax: Optional[plt.Axes] = None,
+    log: bool = True,
+    n_bins: int = 40,
+    bg_color: str = "0.6",
+    sel_color: str = "tab:blue",
+    slice_frac: float = 0.1,
+    bg_alpha: float = 0.6,
+    sel_alpha: float = 0.85,
+    **slice_kwargs: Union[float, Sequence[float]],
+) -> plt.Axes:
+    """Histogram of *col* with optional slice highlighting.
+
+    The PDF is computed as ``count / N_total / delta_bin`` so the integral
+    over all bins equals 1 for the background distribution.  Both
+    distributions share the same bin edges and normalisation base (*N_total*
+    of the full sample), making their shapes directly comparable.
+
+    Parameters
+    ----------
+    table:
+        PHANGS megatable (astropy Table).
+    col:
+        Column to histogram.
+    ax:
+        Axes to draw on.  A new figure/axes is created if ``None``.
+    log:
+        If ``True``, use logarithmic x-axis and log-spaced bins.
+    n_bins:
+        Number of histogram bins.
+    bg_color:
+        Colour for the full-distribution step.
+    sel_color:
+        Colour for the highlighted-slice step.
+    slice_frac:
+        Half-width of the slice as a fraction of the slice value
+        (default ±10%).
+    bg_alpha:
+        Alpha for the background step.
+    sel_alpha:
+        Alpha for the slice step.
+    **slice_kwargs:
+        One optional keyword of the form ``column_name=value`` (scalar) or
+        ``column_name=[v1, v2, ...]`` (multiple values) to highlight one or
+        more narrow slices.  Example::
+
+            hist_plot(t, "Sigma_SFR_HaW4recal", Sigma_gas=10)
+            hist_plot(t, "Sigma_SFR_HaW4recal", Sigma_gas=[10, 30])
+
+    Returns
+    -------
+    `~matplotlib.axes.Axes`
+    """
+    if ax is None:
+        _, ax = plt.subplots()
+
+    v = np.asarray(table[col], dtype=float)
+    valid = np.isfinite(v) & (v > 0) if log else np.isfinite(v)
+    v_all = v[valid]
+
+    slices = _parse_slices(table, valid, slice_kwargs, slice_frac, sel_color)
+
+    edges = bin_edges(v_all, log=log, n=n_bins)
+    n_total = len(v_all)
+
+    pdf_all = _pdf_step(v_all, edges, n_total, log=log)
+    ax.step(edges[:-1], pdf_all, where="post",
+            color=bg_color, alpha=bg_alpha, label="all", zorder=1)
+
+    for i, (mask, color, label) in enumerate(slices):
+        if mask.any():
+            pdf_sel = _pdf_step(v[mask], edges, n_total, log=log)
+            ax.step(edges[:-1], pdf_sel, where="post",
+                    color=color, alpha=sel_alpha, zorder=2 + i, label=label)
+
+    if slices:
+        ax.legend(fontsize="small")
+
+    if log:
+        ax.set_xscale("log")
+
+    ax.set_xlabel(col_label(col))
+    ax.set_ylabel("PDF")
+
+    return ax
+
+
+def _parse_slices(
+    table: Table,
+    valid: np.ndarray,
+    slice_kwargs: dict[str, Any],
+    slice_frac: float,
+    sel_color: str,
+) -> list[tuple[np.ndarray, str, str]]:
+    """Resolve slice kwargs into a list of (mask, color, label) tuples.
+
+    Accepts scalar or sequence values for each slice kwarg, e.g.::
+
+        Sigma_gas=10           → one slice
+        Sigma_gas=[10, 30]     → two slices, colors from tab10
+
+    Parameters
+    ----------
+    table:
+        Megatable.
+    valid:
+        Boolean array of rows that are finite/positive for the plotted columns.
+    slice_kwargs:
+        Raw ``**kwargs`` from the caller — values may be scalar or sequence.
+    slice_frac:
+        Fractional half-width of each slice window.
+    sel_color:
+        Colour used when there is exactly one slice value.
+
+    Returns
+    -------
+    List of ``(mask, color, label)`` — one entry per slice value.
+    """
+    results: list[tuple[np.ndarray, str, str]] = []
+    for scol, raw_val in slice_kwargs.items():
+        if scol not in table.colnames:
+            continue
+        vals: list[float] = (
+            list(raw_val)
+            if isinstance(raw_val, Sequence) and not isinstance(raw_val, str)
+            else [float(raw_val)]
+        )
+        n = len(vals)
+        colors = (
+            [sel_color]
+            if n == 1
+            else [plt.cm.tab10(i / 10) for i in range(n)]
+        )
+        sym = COLUMN_LABELS.get(scol, scol).split("[")[0].strip()
+        sv = np.asarray(table[scol], dtype=float)
+        for val, color in zip(vals, colors):
+            lo = val * (1.0 - slice_frac)
+            hi = val * (1.0 + slice_frac)
+            mask = valid & (sv >= lo) & (sv <= hi)
+            label = rf"{sym} $\in$ [{lo:.3g}, {hi:.3g}]"
+            results.append((mask, color, label))
+        break  # one slice column supported
+    return results

--- a/prfm/prfm.py
+++ b/prfm/prfm.py
@@ -125,13 +125,28 @@ def get_weights(
     >>> import prfm
     >>> H, W_gas, W_star, W_dm = prfm.get_weights(Sigma_gas, Sigma_star, Omega_d, H_star, sigma_eff)
     """
+    w_gas = Sigma_gas is not None
+    w_star = Sigma_star is not None
+    w_dm = Omega_d is not None
     H_gas = get_scale_height(
-        Sigma_gas, Sigma_star, Omega_d, H_star, sigma_eff, zeta_d=zeta_d, method=method
+        Sigma_gas, Sigma_star, Omega_d, H_star, sigma_eff, zeta_d=zeta_d, method=method,
+        wgas=w_gas, wstar=w_star, wdm=w_dm,
     )
 
-    W_gas = get_weight_gas(Sigma_gas)
-    W_star = get_weight_star(Sigma_gas, H_gas, Sigma_star, H_star)
-    W_dm = get_weight_dm(Sigma_gas, H_gas, Omega_d, zeta_d=zeta_d)
+    if w_gas:
+        W_gas = get_weight_gas(Sigma_gas)
+    else:
+        W_gas = 0.
+
+    if w_star:
+        W_star = get_weight_star(Sigma_gas, H_gas, Sigma_star, H_star)
+    else:
+        W_star = 0.
+
+    if w_dm:
+        W_dm = get_weight_dm(Sigma_gas, H_gas, Omega_d, zeta_d=zeta_d)
+    else:
+        W_dm = 0.
 
     return H_gas, W_gas, W_star, W_dm
 

--- a/prfm/simulations.py
+++ b/prfm/simulations.py
@@ -138,13 +138,18 @@ class PRFM_data(object):
 # =====================================================================================
 
 
-def add_one_sim(data, xf="Ptot", yf="SFR", ms=5):
+def add_one_sim(data, xf="Ptot", yf="SFR", ms=5, log_x=True, log_y=True):
     c = data.color
     m = "*" if data.paper == "TIGRESS-GC" else "o"
     x = getattr(data, "log_{}".format(xf))
     y = getattr(data, "log_{}".format(yf))
     xerr = getattr(data, "log_{}_std".format(xf))
     yerr = getattr(data, "log_{}_std".format(yf))
+    if not log_x:
+        x, xerr = get_log_errorbars(x, xerr)
+    if not log_y:
+        y, yerr = get_log_errorbars(y, yerr)
+
     p = plt.errorbar(
         x,
         y,
@@ -212,12 +217,14 @@ def add_ncr_sim(data, xf="Ptot", yf="SFR", ms=5, legend=4):
 
 
 def add_PSFR_model_line(
-    Wmin=2, Wmax=8, Z=None, labels=True, model="tigress-classic", **kwargs
+    Wmin=2, Wmax=8, Z=None, labels=True, model="tigress-classic",
+    log_x=True, log_y=True, **kwargs
 ):
     Wtmp = np.logspace(Wmin, Wmax)
+    sfr = get_sfr(Wtmp * _kbol_cgs, Z=Z, Ytot=model) / _sfr_cgs
     plt.plot(
-        np.log10(Wtmp),
-        np.log10(get_sfr(Wtmp * _kbol_cgs, Z=Z, Ytot=model) / _sfr_cgs),
+        np.log10(Wtmp) if log_x else Wtmp,
+        np.log10(sfr) if log_y else sfr,
         **kwargs,
     )
     if labels:
@@ -239,7 +246,7 @@ def add_PSFR_model_lines(Wmin=2, Wmax=8, model="classic"):
         )
 
 
-def add_PSFR_ncr_model_lines(Wmin=2, Wmax=8):
+def add_PSFR_ncr_model_lines(Wmin=2, Wmax=8, **kwargs):
     for Z in [0.1, 0.3, 1, 3]:
         add_PSFR_model_line(
             Wmin=Wmin,
@@ -247,6 +254,7 @@ def add_PSFR_ncr_model_lines(Wmin=2, Wmax=8):
             Z=Z,
             model="tigress-ncr-decomp",
             color=get_ncr_color(Z),
+            **kwargs,
             label=r"$\Upsilon:$" + f"tigress-ncr Z={Z}",
         )
 
@@ -645,3 +653,43 @@ def load_sim_data():
         d.color = colors[d.paper]
         data[d.paper] = d
     return data
+
+import numpy as np
+
+def get_log_errorbars(log_mean, log_std, base=10):
+    """
+    Converts mean and standard deviation from log-space into linear-space
+    center points and asymmetric error distances for Matplotlib.
+
+    Parameters:
+    -----------
+    log_mean : array_like
+        The mean values calculated in log-space.
+    log_std : array_like
+        The standard deviation values calculated in log-space.
+    base : float, optional
+        The logarithmic base used (default is 10. Use np.e for natural log).
+
+    Returns:
+    --------
+    y_center : numpy.ndarray
+        The geometric center points in linear space.
+    asymmetric_error : list of numpy.ndarray
+        A 2-element list [lower_errors, upper_errors] ready for Matplotlib's `yerr`.
+    """
+    # Ensure inputs are numpy arrays for element-wise math
+    log_mean = np.asarray(log_mean)
+    log_std = np.asarray(log_std)
+
+    # 1. Transform back to linear space
+    y_center = base ** log_mean
+
+    # 2. Calculate the absolute bounds in linear space
+    lower_bound = base ** (log_mean - log_std)
+    upper_bound = base ** (log_mean + log_std)
+
+    # 3. Calculate the distances from the center point
+    yerr_lower = y_center - lower_bound
+    yerr_upper = upper_bound - y_center
+
+    return y_center, [yerr_lower, yerr_upper]

--- a/prfm/simulations.py
+++ b/prfm/simulations.py
@@ -654,7 +654,6 @@ def load_sim_data():
         data[d.paper] = d
     return data
 
-import numpy as np
 
 def get_log_errorbars(log_mean, log_std, base=10):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jupyter-book
+jupyter-book<2
 matplotlib
 numpy
 scipy

--- a/scripts/download_phangs.py
+++ b/scripts/download_phangs.py
@@ -1,0 +1,88 @@
+"""
+Download the PHANGS megatable v4.0 public release.
+
+Usage
+-----
+# Download all annulus files (default, ~10 MB):
+python scripts/download_phangs.py
+
+# Download a specific aperture type:
+python scripts/download_phangs.py --aperture hexagon
+
+# Download all three aperture types (~200 MB total):
+python scripts/download_phangs.py --aperture all
+
+# Download a subset of galaxies:
+python scripts/download_phangs.py --galaxies NGC0628 NGC1097 IC1954
+
+# Force re-download even if files already exist:
+python scripts/download_phangs.py --force
+
+# Custom output directory:
+python scripts/download_phangs.py --dest data/my_phangs
+"""
+
+import argparse
+from pathlib import Path
+
+# Add repo root to path so we can import prfm without installing
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from prfm.phangs import download, list_galaxies
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Download PHANGS megatable ECSV files (Sun+2022 v4.0)"
+    )
+    parser.add_argument(
+        "--dest",
+        default="data/phangs_megatable",
+        help="Destination directory (default: data/phangs_megatable)",
+    )
+    parser.add_argument(
+        "--aperture",
+        default="annulus",
+        choices=["annulus", "gauss", "hexagon", "all"],
+        help="Aperture type to download (default: annulus)",
+    )
+    parser.add_argument(
+        "--galaxies",
+        nargs="+",
+        metavar="GALAXY",
+        default=None,
+        help="Subset of galaxy names (default: all 90)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-download even if files already exist",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Print available galaxy names and exit",
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        for g in list_galaxies():
+            print(g)
+        return
+
+    dest = Path(args.dest)
+    print(f"Downloading to: {dest.resolve()}")
+
+    paths = download(
+        dest_dir=dest,
+        aperture=args.aperture,
+        galaxies=args.galaxies,
+        force=args.force,
+    )
+
+    print(f"Done. {len(paths)} file(s) in {dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/inspect_phangs_columns.py
+++ b/scripts/inspect_phangs_columns.py
@@ -1,8 +1,13 @@
 """
 Quick inspection of PHANGS megatable columns, dtypes, units, and NaN coverage.
 Output is printed to stdout.
+
+Usage
+-----
+python scripts/inspect_phangs_columns.py [--aperture annulus|gauss|hexagon]
 """
 
+import argparse
 from pathlib import Path
 
 import numpy as np
@@ -10,7 +15,13 @@ from prfm import phangs
 
 REPO_ROOT = Path(__file__).parent.parent
 
-t = phangs.load_all(REPO_ROOT / "data/phangs_megatable", aperture="annulus")
+parser = argparse.ArgumentParser()
+parser.add_argument("--aperture", default="annulus",
+                    choices=["annulus", "gauss", "hexagon"])
+args = parser.parse_args()
+
+t = phangs.load_all(REPO_ROOT / "data/phangs_megatable", aperture=args.aperture)
+print(f"Aperture   : {args.aperture}")
 t = phangs.compute_prfm_inputs(t)
 
 print(f"Total rows : {len(t)}")

--- a/scripts/inspect_phangs_columns.py
+++ b/scripts/inspect_phangs_columns.py
@@ -1,0 +1,34 @@
+"""
+Quick inspection of PHANGS megatable columns, dtypes, units, and NaN coverage.
+Output is printed to stdout.
+"""
+
+from pathlib import Path
+
+import numpy as np
+from prfm import phangs
+
+REPO_ROOT = Path(__file__).parent.parent
+
+t = phangs.load_all(REPO_ROOT / "data/phangs_megatable", aperture="annulus")
+t = phangs.compute_prfm_inputs(t)
+
+print(f"Total rows : {len(t)}")
+print(f"Galaxies   : {len(set(t['GALAXY']))}")
+print()
+print(f"{'Column':<40} {'Unit':<25} {'dtype':<10} {'NaN%':>6}  {'min':>12}  {'max':>12}")
+print("-" * 115)
+for col in t.colnames:
+    c = t[col]
+    unit = str(getattr(c, "unit", "")) or ""
+    dtype = str(c.dtype)
+    try:
+        vals = np.asarray(c, dtype=float)
+        nan_pct = 100.0 * np.sum(~np.isfinite(vals)) / len(vals)
+        finite = vals[np.isfinite(vals)]
+        vmin = f"{finite.min():.3g}" if len(finite) else "—"
+        vmax = f"{finite.max():.3g}" if len(finite) else "—"
+    except (TypeError, ValueError):
+        nan_pct = float("nan")
+        vmin = vmax = "—"
+    print(f"{col:<40} {unit:<25} {dtype:<10} {nan_pct:>6.1f}%  {vmin:>12}  {vmax:>12}")

--- a/scripts/inspect_phangs_columns.py
+++ b/scripts/inspect_phangs_columns.py
@@ -20,26 +20,29 @@ parser.add_argument("--aperture", default="annulus",
                     choices=["annulus", "gauss", "hexagon"])
 args = parser.parse_args()
 
-t = phangs.load_all(REPO_ROOT / "data/phangs_megatable", aperture=args.aperture)
+tdict = phangs.load_all(REPO_ROOT / "data/phangs_megatable", aperture=args.aperture)
+# t = phangs.vstack_tables(tdict)
 print(f"Aperture   : {args.aperture}")
-t = phangs.compute_prfm_inputs(t)
+# t = phangs.compute_prfm_inputs(t)
 
-print(f"Total rows : {len(t)}")
-print(f"Galaxies   : {len(set(t['GALAXY']))}")
-print()
-print(f"{'Column':<40} {'Unit':<25} {'dtype':<10} {'NaN%':>6}  {'min':>12}  {'max':>12}")
-print("-" * 115)
-for col in t.colnames:
-    c = t[col]
-    unit = str(getattr(c, "unit", "")) or ""
-    dtype = str(c.dtype)
-    try:
-        vals = np.asarray(c, dtype=float)
-        nan_pct = 100.0 * np.sum(~np.isfinite(vals)) / len(vals)
-        finite = vals[np.isfinite(vals)]
-        vmin = f"{finite.min():.3g}" if len(finite) else "—"
-        vmax = f"{finite.max():.3g}" if len(finite) else "—"
-    except (TypeError, ValueError):
-        nan_pct = float("nan")
-        vmin = vmax = "—"
-    print(f"{col:<40} {unit:<25} {dtype:<10} {nan_pct:>6.1f}%  {vmin:>12}  {vmax:>12}")
+for g, t in tdict.items():
+    print(f"\nGalaxy: {g}")
+    print(f"Total rows : {len(t)}")
+    # print(f"Galaxies   : {}")
+    print()
+    print(f"{'Column':<40} {'Unit':<25} {'dtype':<10} {'NaN%':>6}  {'min':>12}  {'max':>12}")
+    print("-" * 115)
+    for col in t.colnames:
+        c = t[col]
+        unit = str(getattr(c, "unit", "")) or ""
+        dtype = str(c.dtype)
+        try:
+            vals = np.asarray(c, dtype=float)
+            nan_pct = 100.0 * np.sum(~np.isfinite(vals)) / len(vals)
+            finite = vals[np.isfinite(vals)]
+            vmin = f"{finite.min():.3g}" if len(finite) else "—"
+            vmax = f"{finite.max():.3g}" if len(finite) else "—"
+        except (TypeError, ValueError):
+            nan_pct = float("nan")
+            vmin = vmax = "—"
+        print(f"{col:<40} {unit:<25} {dtype:<10} {nan_pct:>6.1f}%  {vmin:>12}  {vmax:>12}")

--- a/scripts/phangs_explore_correlations.py
+++ b/scripts/phangs_explore_correlations.py
@@ -19,6 +19,7 @@ import numpy as np
 from scipy import stats
 
 from prfm import phangs
+from prfm.phangs_plot import build_matrix, resolve_columns, to_log_or_raw
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--aperture", default="annulus",
@@ -28,10 +29,6 @@ args = parser.parse_args()
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-
-_SUFFIX = {"annulus": "", "gauss": "_gauss", "hexagon": "_hexagon"}
-sfx = _SUFFIX[args.aperture]
-_NO_SUFFIX = {"Sigma_gas", "H_star", "Omega_d", "Zprime"}
 
 # Base columns (suffix applied at load time): (base_name, x_label, log_scale)
 _BASE_COLS: list[tuple[str, str, bool]] = [
@@ -50,44 +47,17 @@ DATA_DIR = REPO_ROOT / "data/phangs_megatable"
 OUT_DIR = REPO_ROOT / "figures/phangs" / args.aperture
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def to_log_or_raw(t, col: str, log: bool) -> np.ndarray:
-    v = np.asarray(t[col], dtype=float)
-    if log:
-        with np.errstate(divide="ignore", invalid="ignore"):
-            v = np.log10(np.where(v > 0, v, np.nan))
-    return v
-
-
-def build_matrix(t, cols: list[tuple[str, str, bool]]) -> tuple[np.ndarray, list[str]]:
-    """Build a 2-D array (N_valid_rows × N_cols) with valid rows only."""
-    arrays = [to_log_or_raw(t, col, log) for col, _, log in cols]
-    stacked = np.column_stack(arrays)          # (N_rows, N_cols)
-    valid = np.all(np.isfinite(stacked), axis=1)
-    labels = [lbl for _, lbl, _ in cols]
-    return stacked[valid], labels
-
-
-# ---------------------------------------------------------------------------
 # Load data
 # ---------------------------------------------------------------------------
 
 print(f"Loading PHANGS {args.aperture} data…")
 t = phangs.load_all(DATA_DIR, aperture=args.aperture)
+t = phangs.vstack_tables(t)
 if args.aperture == "annulus":
     t = phangs.compute_prfm_inputs(t)
 
 # Resolve actual column names, keep only those present in this aperture's table
-COLS: list[tuple[str, str, bool]] = []
-for base, label, log in _BASE_COLS:
-    col = base if base in _NO_SUFFIX else base + sfx
-    if col in t.colnames:
-        COLS.append((col, label, log))
-    elif base in t.colnames:
-        COLS.append((base, label, log))
+COLS = resolve_columns(_BASE_COLS, t, aperture=args.aperture)
 
 r_gal_all = np.asarray(t["r_gal"], dtype=float)
 

--- a/scripts/phangs_explore_correlations.py
+++ b/scripts/phangs_explore_correlations.py
@@ -1,15 +1,16 @@
 """
 Correlation exploration of PHANGS megatable key fields.
 
-Produces two figures saved under figures/phangs/:
+Produces two figures saved under figures/phangs/<aperture>/:
   correlation_matrix.png   -- Spearman rank correlation heatmap
   scatter_matrix.png       -- scatter matrix colored by r_gal
 
 Usage
 -----
-python scripts/phangs_explore_correlations.py
+python scripts/phangs_explore_correlations.py [--aperture annulus|gauss|hexagon]
 """
 
+import argparse
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -19,12 +20,21 @@ from scipy import stats
 
 from prfm import phangs
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--aperture", default="annulus",
+                    choices=["annulus", "gauss", "hexagon"])
+args = parser.parse_args()
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
-# Columns for the scatter/correlation matrix (log-transform where noted)
-COLS: list[tuple[str, str, bool]] = [
+_SUFFIX = {"annulus": "", "gauss": "_gauss", "hexagon": "_hexagon"}
+sfx = _SUFFIX[args.aperture]
+_NO_SUFFIX = {"Sigma_gas", "H_star", "Omega_d", "Zprime"}
+
+# Base columns (suffix applied at load time): (base_name, x_label, log_scale)
+_BASE_COLS: list[tuple[str, str, bool]] = [
     ("Sigma_gas",           r"$\Sigma_\mathrm{gas}$",  True),
     ("Sigma_mol",           r"$\Sigma_\mathrm{mol}$",  True),
     ("Sigma_atom",          r"$\Sigma_\mathrm{atom}$", True),
@@ -37,7 +47,7 @@ COLS: list[tuple[str, str, bool]] = [
 
 REPO_ROOT = Path(__file__).parent.parent
 DATA_DIR = REPO_ROOT / "data/phangs_megatable"
-OUT_DIR = REPO_ROOT / "figures/phangs"
+OUT_DIR = REPO_ROOT / "figures/phangs" / args.aperture
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -65,9 +75,20 @@ def build_matrix(t, cols: list[tuple[str, str, bool]]) -> tuple[np.ndarray, list
 # Load data
 # ---------------------------------------------------------------------------
 
-print("Loading PHANGS annulus data…")
-t = phangs.load_all(DATA_DIR, aperture="annulus")
-t = phangs.compute_prfm_inputs(t)
+print(f"Loading PHANGS {args.aperture} data…")
+t = phangs.load_all(DATA_DIR, aperture=args.aperture)
+if args.aperture == "annulus":
+    t = phangs.compute_prfm_inputs(t)
+
+# Resolve actual column names, keep only those present in this aperture's table
+COLS: list[tuple[str, str, bool]] = []
+for base, label, log in _BASE_COLS:
+    col = base if base in _NO_SUFFIX else base + sfx
+    if col in t.colnames:
+        COLS.append((col, label, log))
+    elif base in t.colnames:
+        COLS.append((base, label, log))
+
 r_gal_all = np.asarray(t["r_gal"], dtype=float)
 
 OUT_DIR.mkdir(parents=True, exist_ok=True)

--- a/scripts/phangs_explore_correlations.py
+++ b/scripts/phangs_explore_correlations.py
@@ -1,0 +1,183 @@
+"""
+Correlation exploration of PHANGS megatable key fields.
+
+Produces two figures saved under figures/phangs/:
+  correlation_matrix.png   -- Spearman rank correlation heatmap
+  scatter_matrix.png       -- scatter matrix colored by r_gal
+
+Usage
+-----
+python scripts/phangs_explore_correlations.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
+import numpy as np
+from scipy import stats
+
+from prfm import phangs
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Columns for the scatter/correlation matrix (log-transform where noted)
+COLS: list[tuple[str, str, bool]] = [
+    ("Sigma_gas",           r"$\Sigma_\mathrm{gas}$",  True),
+    ("Sigma_mol",           r"$\Sigma_\mathrm{mol}$",  True),
+    ("Sigma_atom",          r"$\Sigma_\mathrm{atom}$", True),
+    ("Sigma_star",          r"$\Sigma_\star$",          True),
+    ("H_star",              r"$H_\star$",               True),
+    ("Omega_d",             r"$\Omega_d$",              True),
+    ("Zprime",              r"$Z'$",                    False),
+    ("Sigma_SFR_HaW4recal", r"$\Sigma_\mathrm{SFR}$",  True),
+]
+
+REPO_ROOT = Path(__file__).parent.parent
+DATA_DIR = REPO_ROOT / "data/phangs_megatable"
+OUT_DIR = REPO_ROOT / "figures/phangs"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def to_log_or_raw(t, col: str, log: bool) -> np.ndarray:
+    v = np.asarray(t[col], dtype=float)
+    if log:
+        with np.errstate(divide="ignore", invalid="ignore"):
+            v = np.log10(np.where(v > 0, v, np.nan))
+    return v
+
+
+def build_matrix(t, cols: list[tuple[str, str, bool]]) -> tuple[np.ndarray, list[str]]:
+    """Build a 2-D array (N_valid_rows × N_cols) with valid rows only."""
+    arrays = [to_log_or_raw(t, col, log) for col, _, log in cols]
+    stacked = np.column_stack(arrays)          # (N_rows, N_cols)
+    valid = np.all(np.isfinite(stacked), axis=1)
+    labels = [lbl for _, lbl, _ in cols]
+    return stacked[valid], labels
+
+
+# ---------------------------------------------------------------------------
+# Load data
+# ---------------------------------------------------------------------------
+
+print("Loading PHANGS annulus data…")
+t = phangs.load_all(DATA_DIR, aperture="annulus")
+t = phangs.compute_prfm_inputs(t)
+r_gal_all = np.asarray(t["r_gal"], dtype=float)
+
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+# ---------------------------------------------------------------------------
+# Figure 1: Spearman correlation heatmap
+# ---------------------------------------------------------------------------
+
+# Compute pairwise Spearman correlations on all valid rows per pair
+n = len(COLS)
+rho_mat = np.zeros((n, n))
+pval_mat = np.zeros((n, n))
+
+for i, (ci, _, logi) in enumerate(COLS):
+    vi = to_log_or_raw(t, ci, logi)
+    for j, (cj, _, logj) in enumerate(COLS):
+        vj = to_log_or_raw(t, cj, logj)
+        valid = np.isfinite(vi) & np.isfinite(vj)
+        if valid.sum() >= 10:
+            r, p = stats.spearmanr(vi[valid], vj[valid])
+        else:
+            r, p = np.nan, np.nan
+        rho_mat[i, j] = r
+        pval_mat[i, j] = p
+
+labels = [lbl for _, lbl, _ in COLS]
+
+fig, ax = plt.subplots(figsize=(8, 7))
+im = ax.imshow(rho_mat, vmin=-1, vmax=1, cmap="RdBu_r", aspect="auto")
+cbar = fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+cbar.set_label(r"Spearman $\rho$", fontsize=10)
+
+ax.set_xticks(range(n))
+ax.set_yticks(range(n))
+ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=9)
+ax.set_yticklabels(labels, fontsize=9)
+
+# Annotate with rho values; mark significant ones
+for i in range(n):
+    for j in range(n):
+        r = rho_mat[i, j]
+        if not np.isfinite(r):
+            continue
+        sig = "**" if pval_mat[i, j] < 0.01 else ("*" if pval_mat[i, j] < 0.05 else "")
+        color = "white" if abs(r) > 0.6 else "black"
+        ax.text(j, i, f"{r:.2f}{sig}", ha="center", va="center",
+                fontsize=7, color=color)
+
+ax.set_title("Spearman rank correlation — PHANGS annulus\n"
+             "(log-transformed where marked; * p<0.05, ** p<0.01)", fontsize=10)
+fig.tight_layout()
+out = OUT_DIR / "correlation_matrix.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  Saved {out}")
+
+# ---------------------------------------------------------------------------
+# Figure 2: scatter matrix colored by r_gal
+# ---------------------------------------------------------------------------
+
+data, labels = build_matrix(t, COLS)
+n_valid = data.shape[0]
+
+# Get r_gal for the same valid rows
+arrays_tmp = [to_log_or_raw(t, col, log) for col, _, log in COLS]
+stacked_tmp = np.column_stack(arrays_tmp)
+valid_mask = np.all(np.isfinite(stacked_tmp), axis=1)
+r_valid = r_gal_all[valid_mask]
+
+norm = mcolors.LogNorm(vmin=max(r_valid.min(), 0.1), vmax=r_valid.max())
+cmap = plt.cm.plasma_r
+
+n = len(COLS)
+fig, axes = plt.subplots(n, n, figsize=(n * 2.0, n * 2.0))
+
+for i in range(n):
+    for j in range(n):
+        ax = axes[i, j]
+        if i == j:
+            # diagonal: histogram of column i
+            ax.hist(data[:, i], bins=30, color="gray", alpha=0.7, density=True)
+            ax.set_yticks([])
+        else:
+            sc = ax.scatter(data[:, j], data[:, i],
+                            c=r_valid, cmap=cmap, norm=norm,
+                            s=1, alpha=0.4, rasterized=True, linewidths=0)
+        # axis labels on edges only
+        if i == n - 1:
+            ax.set_xlabel(labels[j], fontsize=7)
+        else:
+            ax.set_xticklabels([])
+        if j == 0:
+            ax.set_ylabel(labels[i], fontsize=7)
+        else:
+            ax.set_yticklabels([])
+        ax.tick_params(labelsize=6)
+
+# Colorbar on the right
+fig.subplots_adjust(right=0.88, hspace=0.05, wspace=0.05)
+cax = fig.add_axes([0.90, 0.15, 0.02, 0.7])
+sm = plt.cm.ScalarMappable(cmap=cmap, norm=norm)
+sm.set_array([])
+cb = fig.colorbar(sm, cax=cax)
+cb.set_label(r"$r_\mathrm{gal}$ [kpc]", fontsize=9)
+
+fig.suptitle(f"PHANGS scatter matrix — {n_valid} valid rows, colored by $r_{{\\rm gal}}$",
+             fontsize=10, y=0.995)
+out = OUT_DIR / "scatter_matrix.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  Saved {out}")
+
+print("Done.")

--- a/scripts/phangs_explore_fields.py
+++ b/scripts/phangs_explore_fields.py
@@ -1,16 +1,17 @@
 """
 Histogram exploration of PHANGS megatable key fields.
 
-Produces three figures saved under figures/phangs/:
+Produces three figures saved under figures/phangs/<aperture>/:
   field_distributions.png       -- overall distribution of each field (all data)
   field_distributions_bygal.png -- per-galaxy distributions overlaid
   field_distributions_byrgal.png -- distributions split by galactocentric radius bin
 
 Usage
 -----
-python scripts/phangs_explore_fields.py
+python scripts/phangs_explore_fields.py [--aperture annulus|gauss|hexagon]
 """
 
+import argparse
 from pathlib import Path
 
 import matplotlib.pyplot as plt
@@ -18,12 +19,22 @@ import numpy as np
 
 from prfm import phangs
 
+parser = argparse.ArgumentParser()
+parser.add_argument("--aperture", default="annulus",
+                    choices=["annulus", "gauss", "hexagon"])
+args = parser.parse_args()
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
-# Key columns to examine: (column_name, x_label, log_scale)
-FIELDS: list[tuple[str, str, bool]] = [
+# Aperture suffix: gauss/hexagon files append the aperture name to column names
+_SUFFIX = {"annulus": "", "gauss": "_gauss", "hexagon": "_hexagon"}
+sfx = _SUFFIX[args.aperture]
+
+# Base columns (suffix applied automatically below): (base_name, x_label, log_scale)
+# Columns that always keep their base name (no suffix in any aperture): r_gal, Zprime
+_BASE_FIELDS: list[tuple[str, str, bool]] = [
     ("r_gal",               r"$r_\mathrm{gal}$ [kpc]",                    False),
     ("Sigma_mol",           r"$\Sigma_\mathrm{mol}$ [$M_\odot$ pc$^{-2}$]", True),
     ("Sigma_atom",          r"$\Sigma_\mathrm{atom}$ [$M_\odot$ pc$^{-2}$]", True),
@@ -39,6 +50,11 @@ FIELDS: list[tuple[str, str, bool]] = [
     ("alpha_CO21_S20",      r"$\alpha_\mathrm{CO}$ [S20]",                  True),
 ]
 
+# Columns that never get a suffix (shared across apertures)
+_NO_SUFFIX = {"r_gal", "Zprime", "alpha_CO21_S20",
+              "rho_star_mp", "V_circ_CO21_URC", "Omega_d", "H_star",
+              "Sigma_gas"}  # Sigma_gas is derived, added by compute_prfm_inputs
+
 # Radial bins for the by-r_gal figure
 RGAL_BINS = [(0, 2), (2, 5), (5, 10), (10, 999)]
 RGAL_LABELS = [r"$r<2$ kpc", r"$2-5$ kpc", r"$5-10$ kpc", r"$r>10$ kpc"]
@@ -46,7 +62,7 @@ RGAL_COLORS = ["#c0392b", "#e67e22", "#27ae60", "#2980b9"]
 
 REPO_ROOT = Path(__file__).parent.parent
 DATA_DIR = REPO_ROOT / "data/phangs_megatable"
-OUT_DIR = REPO_ROOT / "figures/phangs"
+OUT_DIR = REPO_ROOT / "figures/phangs" / args.aperture
 N_BINS = 40
 
 # ---------------------------------------------------------------------------
@@ -73,9 +89,19 @@ def bin_edges(vals: np.ndarray, log: bool, n: int = N_BINS) -> np.ndarray:
 # Load data
 # ---------------------------------------------------------------------------
 
-print("Loading PHANGS annulus data…")
-t = phangs.load_all(DATA_DIR, aperture="annulus")
-t = phangs.compute_prfm_inputs(t)
+print(f"Loading PHANGS {args.aperture} data…")
+t = phangs.load_all(DATA_DIR, aperture=args.aperture)
+if args.aperture == "annulus":
+    t = phangs.compute_prfm_inputs(t)
+
+# Resolve actual column names (apply suffix where the column exists with it)
+FIELDS: list[tuple[str, str, bool]] = []
+for base, label, log in _BASE_FIELDS:
+    col = base if base in _NO_SUFFIX else base + sfx
+    if col in t.colnames:
+        FIELDS.append((col, label, log))
+    elif base in t.colnames:      # fallback to unsuffixed
+        FIELDS.append((base, label, log))
 
 galaxies = sorted(set(t["GALAXY"]))
 gal_cmap = plt.cm.tab20

--- a/scripts/phangs_explore_fields.py
+++ b/scripts/phangs_explore_fields.py
@@ -18,6 +18,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from prfm import phangs
+from prfm.phangs_plot import (
+    RGAL_BINS,
+    RGAL_COLORS,
+    RGAL_LABELS,
+    bin_edges,
+    clean,
+    resolve_columns,
+)
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--aperture", default="annulus",
@@ -28,12 +36,7 @@ args = parser.parse_args()
 # Configuration
 # ---------------------------------------------------------------------------
 
-# Aperture suffix: gauss/hexagon files append the aperture name to column names
-_SUFFIX = {"annulus": "", "gauss": "_gauss", "hexagon": "_hexagon"}
-sfx = _SUFFIX[args.aperture]
-
 # Base columns (suffix applied automatically below): (base_name, x_label, log_scale)
-# Columns that always keep their base name (no suffix in any aperture): r_gal, Zprime
 _BASE_FIELDS: list[tuple[str, str, bool]] = [
     ("r_gal",               r"$r_\mathrm{gal}$ [kpc]",                    False),
     ("Sigma_mol",           r"$\Sigma_\mathrm{mol}$ [$M_\odot$ pc$^{-2}$]", True),
@@ -50,40 +53,9 @@ _BASE_FIELDS: list[tuple[str, str, bool]] = [
     ("alpha_CO21_S20",      r"$\alpha_\mathrm{CO}$ [S20]",                  True),
 ]
 
-# Columns that never get a suffix (shared across apertures)
-_NO_SUFFIX = {"r_gal", "Zprime", "alpha_CO21_S20",
-              "rho_star_mp", "V_circ_CO21_URC", "Omega_d", "H_star",
-              "Sigma_gas"}  # Sigma_gas is derived, added by compute_prfm_inputs
-
-# Radial bins for the by-r_gal figure
-RGAL_BINS = [(0, 2), (2, 5), (5, 10), (10, 999)]
-RGAL_LABELS = [r"$r<2$ kpc", r"$2-5$ kpc", r"$5-10$ kpc", r"$r>10$ kpc"]
-RGAL_COLORS = ["#c0392b", "#e67e22", "#27ae60", "#2980b9"]
-
 REPO_ROOT = Path(__file__).parent.parent
 DATA_DIR = REPO_ROOT / "data/phangs_megatable"
 OUT_DIR = REPO_ROOT / "figures/phangs" / args.aperture
-N_BINS = 40
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def clean(vals: np.ndarray, log: bool) -> np.ndarray:
-    """Return finite, positive (if log) values as a plain float array."""
-    v = np.asarray(vals, dtype=float)
-    mask = np.isfinite(v)
-    if log:
-        mask &= v > 0
-    return v[mask]
-
-
-def bin_edges(vals: np.ndarray, log: bool, n: int = N_BINS) -> np.ndarray:
-    if log:
-        return np.logspace(np.log10(vals.min()), np.log10(vals.max()), n + 1)
-    return np.linspace(vals.min(), vals.max(), n + 1)
-
 
 # ---------------------------------------------------------------------------
 # Load data
@@ -91,17 +63,12 @@ def bin_edges(vals: np.ndarray, log: bool, n: int = N_BINS) -> np.ndarray:
 
 print(f"Loading PHANGS {args.aperture} data…")
 t = phangs.load_all(DATA_DIR, aperture=args.aperture)
+t = phangs.vstack_tables(t)
 if args.aperture == "annulus":
     t = phangs.compute_prfm_inputs(t)
 
 # Resolve actual column names (apply suffix where the column exists with it)
-FIELDS: list[tuple[str, str, bool]] = []
-for base, label, log in _BASE_FIELDS:
-    col = base if base in _NO_SUFFIX else base + sfx
-    if col in t.colnames:
-        FIELDS.append((col, label, log))
-    elif base in t.colnames:      # fallback to unsuffixed
-        FIELDS.append((base, label, log))
+FIELDS = resolve_columns(_BASE_FIELDS, t, aperture=args.aperture)
 
 galaxies = sorted(set(t["GALAXY"]))
 gal_cmap = plt.cm.tab20

--- a/scripts/phangs_explore_fields.py
+++ b/scripts/phangs_explore_fields.py
@@ -1,0 +1,205 @@
+"""
+Histogram exploration of PHANGS megatable key fields.
+
+Produces three figures saved under figures/phangs/:
+  field_distributions.png       -- overall distribution of each field (all data)
+  field_distributions_bygal.png -- per-galaxy distributions overlaid
+  field_distributions_byrgal.png -- distributions split by galactocentric radius bin
+
+Usage
+-----
+python scripts/phangs_explore_fields.py
+"""
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from prfm import phangs
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+# Key columns to examine: (column_name, x_label, log_scale)
+FIELDS: list[tuple[str, str, bool]] = [
+    ("r_gal",               r"$r_\mathrm{gal}$ [kpc]",                    False),
+    ("Sigma_mol",           r"$\Sigma_\mathrm{mol}$ [$M_\odot$ pc$^{-2}$]", True),
+    ("Sigma_atom",          r"$\Sigma_\mathrm{atom}$ [$M_\odot$ pc$^{-2}$]", True),
+    ("Sigma_gas",           r"$\Sigma_\mathrm{gas}$ [$M_\odot$ pc$^{-2}$]", True),
+    ("Sigma_star",          r"$\Sigma_\star$ [$M_\odot$ pc$^{-2}$]",       True),
+    ("rho_star_mp",         r"$\rho_\star$ [$M_\odot$ pc$^{-3}$]",         True),
+    ("H_star",              r"$H_\star$ [pc]",                              True),
+    ("V_circ_CO21_URC",     r"$V_\mathrm{circ}$ [km s$^{-1}$]",            False),
+    ("Omega_d",             r"$\Omega_d$ [km s$^{-1}$ kpc$^{-1}$]",        True),
+    ("Zprime",              r"$Z'$ [$Z_\odot$]",                            False),
+    ("Sigma_SFR_HaW4recal", r"$\Sigma_\mathrm{SFR}^\mathrm{Ha+W4}$ [$M_\odot$ yr$^{-1}$ kpc$^{-2}$]", True),
+    ("Sigma_SFR_FUVW4recal",r"$\Sigma_\mathrm{SFR}^\mathrm{FUV+W4}$ [$M_\odot$ yr$^{-1}$ kpc$^{-2}$]", True),
+    ("alpha_CO21_S20",      r"$\alpha_\mathrm{CO}$ [S20]",                  True),
+]
+
+# Radial bins for the by-r_gal figure
+RGAL_BINS = [(0, 2), (2, 5), (5, 10), (10, 999)]
+RGAL_LABELS = [r"$r<2$ kpc", r"$2-5$ kpc", r"$5-10$ kpc", r"$r>10$ kpc"]
+RGAL_COLORS = ["#c0392b", "#e67e22", "#27ae60", "#2980b9"]
+
+REPO_ROOT = Path(__file__).parent.parent
+DATA_DIR = REPO_ROOT / "data/phangs_megatable"
+OUT_DIR = REPO_ROOT / "figures/phangs"
+N_BINS = 40
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def clean(vals: np.ndarray, log: bool) -> np.ndarray:
+    """Return finite, positive (if log) values as a plain float array."""
+    v = np.asarray(vals, dtype=float)
+    mask = np.isfinite(v)
+    if log:
+        mask &= v > 0
+    return v[mask]
+
+
+def bin_edges(vals: np.ndarray, log: bool, n: int = N_BINS) -> np.ndarray:
+    if log:
+        return np.logspace(np.log10(vals.min()), np.log10(vals.max()), n + 1)
+    return np.linspace(vals.min(), vals.max(), n + 1)
+
+
+# ---------------------------------------------------------------------------
+# Load data
+# ---------------------------------------------------------------------------
+
+print("Loading PHANGS annulus data…")
+t = phangs.load_all(DATA_DIR, aperture="annulus")
+t = phangs.compute_prfm_inputs(t)
+
+galaxies = sorted(set(t["GALAXY"]))
+gal_cmap = plt.cm.tab20
+gal_colors = {g: gal_cmap(i / len(galaxies)) for i, g in enumerate(galaxies)}
+r_gal_all = np.asarray(t["r_gal"], dtype=float)
+
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+# ---------------------------------------------------------------------------
+# Figure 1: overall distributions
+# ---------------------------------------------------------------------------
+
+ncols = 4
+nrows = int(np.ceil(len(FIELDS) / ncols))
+fig, axes = plt.subplots(nrows, ncols, figsize=(ncols * 3.5, nrows * 2.8))
+axes = axes.flatten()
+
+for ax, (col, xlabel, log) in zip(axes, FIELDS):
+    v = clean(np.asarray(t[col], dtype=float), log)
+    if len(v) == 0:
+        ax.set_visible(False)
+        continue
+    edges = bin_edges(v, log)
+    ax.hist(v, bins=edges, color="steelblue", edgecolor="none", alpha=0.85, density=True)
+    ax.set_xlabel(xlabel, fontsize=8)
+    ax.set_ylabel("PDF", fontsize=8)
+    if log:
+        ax.set_xscale("log")
+    nan_pct = 100.0 * (1 - len(v) / len(t))
+    ax.set_title(f"{col}  (NaN {nan_pct:.0f}%)", fontsize=7, pad=3)
+    ax.tick_params(labelsize=7)
+
+for ax in axes[len(FIELDS):]:
+    ax.set_visible(False)
+
+fig.suptitle("PHANGS megatable — key field distributions (all data)", fontsize=11, y=1.01)
+fig.tight_layout()
+out = OUT_DIR / "field_distributions.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  Saved {out}")
+
+# ---------------------------------------------------------------------------
+# Figure 2: per-galaxy distributions
+# ---------------------------------------------------------------------------
+
+fig, axes = plt.subplots(nrows, ncols, figsize=(ncols * 3.5, nrows * 2.8))
+axes = axes.flatten()
+
+for ax, (col, xlabel, log) in zip(axes, FIELDS):
+    v_all = clean(np.asarray(t[col], dtype=float), log)
+    if len(v_all) == 0:
+        ax.set_visible(False)
+        continue
+    edges = bin_edges(v_all, log)
+    # per-galaxy thin lines
+    for gal in galaxies:
+        mask = np.asarray(t["GALAXY"]) == gal
+        v_g = clean(np.asarray(t[col][mask], dtype=float), log)
+        if len(v_g) < 3:
+            continue
+        counts, _ = np.histogram(v_g, bins=edges, density=True)
+        centers = 0.5 * (edges[:-1] + edges[1:])
+        ax.plot(centers, counts, lw=0.6, alpha=0.5, color=gal_colors[gal])
+    # overall thick line
+    counts_all, _ = np.histogram(v_all, bins=edges, density=True)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    ax.plot(centers, counts_all, lw=2, color="black", label="all")
+    ax.set_xlabel(xlabel, fontsize=8)
+    ax.set_ylabel("PDF", fontsize=8)
+    if log:
+        ax.set_xscale("log")
+    ax.set_title(col, fontsize=7, pad=3)
+    ax.tick_params(labelsize=7)
+
+for ax in axes[len(FIELDS):]:
+    ax.set_visible(False)
+
+fig.suptitle("PHANGS — per-galaxy distributions (thin) vs. all (black)", fontsize=11, y=1.01)
+fig.tight_layout()
+out = OUT_DIR / "field_distributions_bygal.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  Saved {out}")
+
+# ---------------------------------------------------------------------------
+# Figure 3: distributions split by r_gal bin
+# ---------------------------------------------------------------------------
+
+fig, axes = plt.subplots(nrows, ncols, figsize=(ncols * 3.5, nrows * 2.8))
+axes = axes.flatten()
+
+for ax, (col, xlabel, log) in zip(axes, FIELDS):
+    v_all = clean(np.asarray(t[col], dtype=float), log)
+    if len(v_all) == 0:
+        ax.set_visible(False)
+        continue
+    edges = bin_edges(v_all, log)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    for (rmin, rmax), label, color in zip(RGAL_BINS, RGAL_LABELS, RGAL_COLORS):
+        rmask = (r_gal_all >= rmin) & (r_gal_all < rmax)
+        v_r = clean(np.asarray(t[col][rmask], dtype=float), log)
+        if len(v_r) < 3:
+            continue
+        counts, _ = np.histogram(v_r, bins=edges, density=True)
+        ax.plot(centers, counts, lw=1.5, color=color, label=label)
+    ax.set_xlabel(xlabel, fontsize=8)
+    ax.set_ylabel("PDF", fontsize=8)
+    if log:
+        ax.set_xscale("log")
+    ax.set_title(col, fontsize=7, pad=3)
+    ax.tick_params(labelsize=7)
+
+# shared legend on first visible axis
+axes[0].legend(fontsize=6, loc="upper right")
+
+for ax in axes[len(FIELDS):]:
+    ax.set_visible(False)
+
+fig.suptitle(r"PHANGS — distributions split by $r_\mathrm{gal}$", fontsize=11, y=1.01)
+fig.tight_layout()
+out = OUT_DIR / "field_distributions_byrgal.png"
+fig.savefig(out, dpi=150, bbox_inches="tight")
+plt.close(fig)
+print(f"  Saved {out}")
+
+print("Done.")

--- a/tests/test_phangs.py
+++ b/tests/test_phangs.py
@@ -232,6 +232,92 @@ class TestFiltering:
 
 
 # ---------------------------------------------------------------------------
+# run_prfm
+# ---------------------------------------------------------------------------
+
+
+class TestRunPRFM:
+    def test_returns_table(self, synthetic_table):
+        out = phangs.run_prfm(synthetic_table)
+        assert isinstance(out, Table)
+
+    def test_output_columns_present(self, synthetic_table):
+        out = phangs.run_prfm(synthetic_table)
+        for col in ("P_weight", "H_gas", "sigma_eff_sol", "Sigma_SFR_pred"):
+            assert col in out.colnames, f"Missing column: {col}"
+
+    def test_same_length_as_input(self, synthetic_table):
+        out = phangs.run_prfm(synthetic_table)
+        assert len(out) == len(synthetic_table)
+
+    def test_output_units_attached(self, synthetic_table):
+        out = phangs.run_prfm(synthetic_table)
+        assert out["P_weight"].unit is not None
+        assert out["H_gas"].unit is not None
+        assert out["sigma_eff_sol"].unit is not None
+        assert out["Sigma_SFR_pred"].unit is not None
+
+    def test_all_rows_finite_for_clean_input(self, synthetic_table):
+        out = phangs.run_prfm(synthetic_table)
+        for col in ("P_weight", "H_gas", "sigma_eff_sol", "Sigma_SFR_pred"):
+            assert np.all(np.isfinite(out[col].value)), f"Non-finite values in {col}"
+
+    def test_invalid_rows_give_nan(self, synthetic_file, tmp_path):
+        """Rows with NaN inputs should produce NaN outputs."""
+        import textwrap
+        ecsv_nan = textwrap.dedent("""\
+            # %ECSV 1.0
+            # ---
+            # datatype:
+            # - {name: r_gal, unit: kpc, datatype: float64}
+            # - {name: V_circ_CO21_URC, unit: km / s, datatype: float64}
+            # - {name: Sigma_mol, unit: solMass / pc2, datatype: float64}
+            # - {name: Sigma_atom, unit: solMass / pc2, datatype: float64}
+            # - {name: Sigma_star, unit: solMass / pc2, datatype: float64}
+            # - {name: rho_star_mp, unit: solMass / pc3, datatype: float64}
+            # - {name: Sigma_SFR_HaW4recal, unit: solMass / (kpc2 yr), datatype: float64}
+            # - {name: Zprime, datatype: float64}
+            # meta:
+            #   GALAXY: TESTNAN
+            # schema: astropy-2.0
+            r_gal V_circ_CO21_URC Sigma_mol Sigma_atom Sigma_star rho_star_mp Sigma_SFR_HaW4recal Zprime
+            1.0 150.0 10.0 5.0 200.0 0.1 0.01 1.0
+            2.0 180.0 nan 4.0 150.0 0.08 0.008 0.9
+        """)
+        f = tmp_path / "TESTNAN_annulus_0p5kpc.ecsv"
+        f.write_text(ecsv_nan)
+        t = phangs.load(f)
+        import warnings
+        with warnings.catch_warnings(record=True):
+            out = phangs.run_prfm(t)
+        assert np.isfinite(out["Sigma_SFR_pred"].value[0])
+        assert np.isnan(out["Sigma_SFR_pred"].value[1])
+
+    def test_sfr_pred_positive_for_valid_rows(self, synthetic_table):
+        out = phangs.run_prfm(synthetic_table)
+        assert np.all(out["Sigma_SFR_pred"].value > 0)
+
+    def test_p_weight_positive_for_valid_rows(self, synthetic_table):
+        out = phangs.run_prfm(synthetic_table)
+        assert np.all(out["P_weight"].value > 0)
+
+    def test_h_gas_positive_for_valid_rows(self, synthetic_table):
+        out = phangs.run_prfm(synthetic_table)
+        assert np.all(out["H_gas"].value > 0)
+
+    def test_accepts_precomputed_inputs(self, synthetic_table):
+        """run_prfm should not recompute if Sigma_gas already present."""
+        t = phangs.compute_prfm_inputs(synthetic_table)
+        out = phangs.run_prfm(t)
+        assert "P_weight" in out.colnames
+
+    def test_zprime_none_skips_metallicity(self, synthetic_table):
+        """zprime_col=None should still produce valid outputs."""
+        out = phangs.run_prfm(synthetic_table, zprime_col=None)
+        assert np.all(np.isfinite(out["Sigma_SFR_pred"].value))
+
+
+# ---------------------------------------------------------------------------
 # Integration tests (require downloaded data)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_phangs.py
+++ b/tests/test_phangs.py
@@ -1,0 +1,269 @@
+"""
+TDD tests for prfm.phangs — PHANGS megatable data handling.
+
+Tests are split into two groups:
+  - Unit tests (no network/disk required): use minimal synthetic ECSV data
+    to verify parsing, derived-quantity formulas, and filtering logic.
+  - Integration tests (require downloaded data): marked with
+    @pytest.mark.integration and skipped automatically when
+    data/phangs_megatable/ is absent.
+
+Run only unit tests (fast):
+    pytest tests/test_phangs.py -m "not integration"
+
+Run all including integration:
+    pytest tests/test_phangs.py
+"""
+
+import textwrap
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.table import Table
+
+DATA_DIR = Path(__file__).parent.parent / "data" / "phangs_megatable"
+HAS_DATA = DATA_DIR.exists() and any(DATA_DIR.glob("*.ecsv"))
+
+integration = pytest.mark.skipif(not HAS_DATA, reason="PHANGS data not downloaded")
+
+# ---------------------------------------------------------------------------
+# Minimal synthetic ECSV fixture
+# ---------------------------------------------------------------------------
+
+SYNTHETIC_ECSV = textwrap.dedent("""\
+    # %ECSV 1.0
+    # ---
+    # datatype:
+    # - {name: r_gal, unit: kpc, datatype: float64}
+    # - {name: V_circ_CO21_URC, unit: km / s, datatype: float64}
+    # - {name: Sigma_mol, unit: solMass / pc2, datatype: float64}
+    # - {name: Sigma_atom, unit: solMass / pc2, datatype: float64}
+    # - {name: Sigma_star, unit: solMass / pc2, datatype: float64}
+    # - {name: rho_star_mp, unit: solMass / pc3, datatype: float64}
+    # - {name: Sigma_SFR_HaW4recal, unit: solMass / (kpc2 yr), datatype: float64}
+    # - {name: Zprime, datatype: float64}
+    # meta:
+    #   GALAXY: TESTGAL
+    #   DIST_MPC: 10.0
+    #   R25_KPC: 5.0
+    # schema: astropy-2.0
+    r_gal V_circ_CO21_URC Sigma_mol Sigma_atom Sigma_star rho_star_mp Sigma_SFR_HaW4recal Zprime
+    1.0 150.0 10.0 5.0 200.0 0.1 0.01 1.0
+    2.0 180.0 8.0 4.0 150.0 0.08 0.008 0.9
+    3.0 200.0 5.0 3.0 100.0 0.05 0.005 0.8
+    4.0 210.0 3.0 2.0 50.0 0.02 0.002 0.7
+    5.0 220.0 1.0 1.5 20.0 0.008 0.001 0.6
+""")
+
+
+@pytest.fixture
+def synthetic_table(synthetic_file):
+    return phangs.load(synthetic_file)
+
+
+@pytest.fixture
+def synthetic_file(tmp_path):
+    f = tmp_path / "TESTGAL_annulus_0p5kpc.ecsv"
+    f.write_text(SYNTHETIC_ECSV)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Import the module under test
+# ---------------------------------------------------------------------------
+
+from prfm import phangs  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# File listing and URL construction
+# ---------------------------------------------------------------------------
+
+
+class TestFileListAndURL:
+    def test_list_files_returns_list(self):
+        files = phangs.list_files()
+        assert isinstance(files, list)
+        assert len(files) > 0
+
+    def test_list_files_ecsv_extension(self):
+        for f in phangs.list_files():
+            assert f.endswith(".ecsv")
+
+    def test_list_files_filter_aperture(self):
+        annulus = phangs.list_files(aperture="annulus")
+        assert all("annulus" in f for f in annulus)
+        hexagon = phangs.list_files(aperture="hexagon")
+        assert all("hexagon" in f for f in hexagon)
+
+    def test_list_files_all_three_apertures(self):
+        for ap in ("annulus", "gauss", "hexagon"):
+            files = phangs.list_files(aperture=ap)
+            assert len(files) > 0, f"No files found for aperture={ap}"
+
+    def test_build_url_contains_filename(self):
+        url = phangs.build_url("NGC0628_annulus_0p5kpc.ecsv")
+        assert "NGC0628_annulus_0p5kpc.ecsv" in url
+        assert url.startswith("http")
+
+    def test_galaxies_list(self):
+        galaxies = phangs.list_galaxies()
+        assert "NGC0628" in galaxies
+        assert "IC1954" in galaxies
+        assert len(galaxies) >= 10
+
+    def test_filename_for_galaxy(self):
+        fname = phangs.filename("NGC0628", aperture="annulus")
+        assert fname == "NGC0628_annulus_0p5kpc.ecsv"
+        fname = phangs.filename("NGC0628", aperture="hexagon")
+        assert fname == "NGC0628_hexagon_1p5kpc.ecsv"
+
+
+# ---------------------------------------------------------------------------
+# Loading a single table
+# ---------------------------------------------------------------------------
+
+
+class TestLoadTable:
+    def test_load_returns_astropy_table(self, synthetic_file):
+        t = phangs.load(synthetic_file)
+        assert isinstance(t, Table)
+
+    def test_load_has_required_columns(self, synthetic_file):
+        t = phangs.load(synthetic_file)
+        for col in ("r_gal", "Sigma_mol", "Sigma_atom", "Sigma_star",
+                    "rho_star_mp", "V_circ_CO21_URC", "Sigma_SFR_HaW4recal"):
+            assert col in t.colnames, f"Missing column: {col}"
+
+    def test_load_preserves_units(self, synthetic_file):
+        t = phangs.load(synthetic_file)
+        assert t["r_gal"].unit is not None
+        assert t["Sigma_mol"].unit is not None
+
+    def test_load_attaches_galaxy_name(self, synthetic_file):
+        t = phangs.load(synthetic_file)
+        assert t.meta.get("GALAXY") == "TESTGAL"
+
+    def test_load_nonexistent_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            phangs.load(tmp_path / "does_not_exist.ecsv")
+
+
+# ---------------------------------------------------------------------------
+# Derived PRFM quantities
+# ---------------------------------------------------------------------------
+
+
+class TestComputePRFMInputs:
+    def test_returns_table_with_new_columns(self, synthetic_table):
+        out = phangs.compute_prfm_inputs(synthetic_table)
+        for col in ("Sigma_gas", "Omega_d", "H_star"):
+            assert col in out.colnames, f"Missing derived column: {col}"
+
+    def test_sigma_gas_equals_mol_plus_atom(self, synthetic_table):
+        out = phangs.compute_prfm_inputs(synthetic_table)
+        expected = synthetic_table["Sigma_mol"] + synthetic_table["Sigma_atom"]
+        np.testing.assert_allclose(out["Sigma_gas"].value, expected.value)
+
+    def test_omega_d_formula(self, synthetic_table):
+        """Omega_d = V_circ / r_gal  (km/s/kpc)"""
+        out = phangs.compute_prfm_inputs(synthetic_table)
+        V = synthetic_table["V_circ_CO21_URC"].value   # km/s
+        r = synthetic_table["r_gal"].value              # kpc
+        expected = V / r
+        np.testing.assert_allclose(out["Omega_d"].value, expected, rtol=1e-10)
+
+    def test_h_star_formula(self, synthetic_table):
+        """H_star = Sigma_star / (2 * rho_star_mp)  [pc]"""
+        out = phangs.compute_prfm_inputs(synthetic_table)
+        Ss = synthetic_table["Sigma_star"].value   # M_sun/pc^2
+        rs = synthetic_table["rho_star_mp"].value  # M_sun/pc^3
+        expected = Ss / (2.0 * rs)                 # pc
+        np.testing.assert_allclose(out["H_star"].value, expected, rtol=1e-10)
+
+    def test_units_attached(self, synthetic_table):
+        out = phangs.compute_prfm_inputs(synthetic_table)
+        assert out["Sigma_gas"].unit is not None
+        assert out["Omega_d"].unit is not None
+        assert out["H_star"].unit is not None
+
+    def test_sigma_gas_positive(self, synthetic_table):
+        out = phangs.compute_prfm_inputs(synthetic_table)
+        assert np.all(out["Sigma_gas"].value > 0)
+
+    def test_h_star_positive(self, synthetic_table):
+        out = phangs.compute_prfm_inputs(synthetic_table)
+        assert np.all(out["H_star"].value > 0)
+
+    def test_omega_d_positive(self, synthetic_table):
+        out = phangs.compute_prfm_inputs(synthetic_table)
+        assert np.all(out["Omega_d"].value > 0)
+
+
+# ---------------------------------------------------------------------------
+# Filtering helpers
+# ---------------------------------------------------------------------------
+
+
+class TestFiltering:
+    def test_valid_rows_removes_nans(self):
+        t = Table({
+            "Sigma_gas": [1.0, float("nan"), 3.0],
+            "Omega_d": [1.0, 2.0, float("nan")],
+            "H_star": [100.0, 200.0, 300.0],
+        })
+        mask = phangs.valid_rows(t, cols=["Sigma_gas", "Omega_d", "H_star"])
+        assert mask.sum() == 1
+        assert mask[0] is np.bool_(True)
+
+    def test_valid_rows_removes_non_positive(self):
+        t = Table({
+            "Sigma_gas": [1.0, 0.0, -1.0, 5.0],
+            "Omega_d": [1.0, 2.0, 3.0, 4.0],
+        })
+        mask = phangs.valid_rows(t, cols=["Sigma_gas", "Omega_d"])
+        assert mask.sum() == 2  # rows 0 and 3
+
+    def test_valid_rows_all_good(self, synthetic_table):
+        out = phangs.compute_prfm_inputs(synthetic_table)
+        mask = phangs.valid_rows(out, cols=["Sigma_gas", "Omega_d", "H_star"])
+        assert mask.sum() == len(out)
+
+
+# ---------------------------------------------------------------------------
+# Integration tests (require downloaded data)
+# ---------------------------------------------------------------------------
+
+
+@integration
+class TestIntegrationLoad:
+    def test_one_file_readable(self):
+        files = sorted(DATA_DIR.glob("*_annulus_0p5kpc.ecsv"))
+        assert len(files) > 0
+        t = phangs.load(files[0])
+        assert len(t) > 0
+
+    def test_galaxy_name_in_meta(self):
+        files = sorted(DATA_DIR.glob("*_annulus_0p5kpc.ecsv"))
+        t = phangs.load(files[0])
+        assert "GALAXY" in t.meta
+
+    def test_prfm_inputs_computable(self):
+        files = sorted(DATA_DIR.glob("*_annulus_0p5kpc.ecsv"))
+        t = phangs.load(files[0])
+        out = phangs.compute_prfm_inputs(t)
+        assert "Sigma_gas" in out.colnames
+
+
+@integration
+class TestIntegrationLoadAll:
+    def test_load_all_returns_stacked_table(self):
+        t = phangs.load_all(DATA_DIR, aperture="annulus")
+        assert isinstance(t, Table)
+        assert len(t) > 0
+        assert "GALAXY" in t.colnames
+
+    def test_load_all_contains_multiple_galaxies(self):
+        t = phangs.load_all(DATA_DIR, aperture="annulus")
+        assert len(set(t["GALAXY"])) > 1

--- a/tests/test_phangs.py
+++ b/tests/test_phangs.py
@@ -320,6 +320,59 @@ class TestRunPRFM:
         out = phangs.run_prfm(synthetic_table, zprime_col=None)
         assert np.all(np.isfinite(out["Sigma_SFR_pred"].value))
 
+    def test_input_table_not_mutated(self, synthetic_table):
+        """run_prfm must return a copy; the original table is unchanged."""
+        cols_before = list(synthetic_table.colnames)
+        phangs.run_prfm(synthetic_table)
+        assert list(synthetic_table.colnames) == cols_before
+
+    def test_variation_omega_d_none(self, synthetic_table):
+        """variation={'Omega_d': None} disables rotation term; output still finite."""
+        out = phangs.run_prfm(synthetic_table, variation={"Omega_d": None})
+        assert np.all(np.isfinite(out["Sigma_SFR_pred"].value))
+
+    def test_variation_sigma_star_scaling(self, synthetic_table):
+        """Scaling Sigma_star via variation changes P_weight relative to default."""
+        out_default = phangs.run_prfm(synthetic_table)
+        out_scaled = phangs.run_prfm(synthetic_table, variation={"Sigma_star": 2.0})
+        assert np.all(out_scaled["P_weight"].value >= out_default["P_weight"].value)
+
+    def test_variation_h_star_scaling(self, synthetic_table):
+        """Scaling H_star via variation changes P_weight relative to default."""
+        out_default = phangs.run_prfm(synthetic_table)
+        out_scaled = phangs.run_prfm(synthetic_table, variation={"H_star": 2.0})
+        assert not np.allclose(
+            out_scaled["P_weight"].value, out_default["P_weight"].value
+        )
+
+    def test_prfm_cols_without_omega_d(self, synthetic_table):
+        """prfm_cols without Omega_d (gravity-only) produces finite outputs."""
+        out = phangs.run_prfm(
+            synthetic_table,
+            prfm_cols=["Sigma_gas", "Sigma_star", "H_star"],
+        )
+        assert np.all(np.isfinite(out["Sigma_SFR_pred"].value))
+
+    def test_invalid_rows_emit_warning(self, synthetic_table):
+        """A warning is emitted when any input row is invalid."""
+        import warnings
+
+        t = phangs.compute_prfm_inputs(synthetic_table.copy())
+        t["Sigma_gas"][0] = np.nan
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            phangs.run_prfm(t)
+        assert any("invalid" in str(w.message).lower() for w in caught)
+
+    def test_alternative_models_produce_finite_output(self, synthetic_table):
+        """Non-default sigma_eff and yield models should still produce finite outputs."""
+        out = phangs.run_prfm(
+            synthetic_table,
+            sigma_eff_model="tigress-classic-mid",
+            yield_model="tigress-classic",
+        )
+        assert np.all(np.isfinite(out["Sigma_SFR_pred"].value))
+
 
 # ---------------------------------------------------------------------------
 # Integration tests (require downloaded data)

--- a/tests/test_phangs.py
+++ b/tests/test_phangs.py
@@ -346,10 +346,13 @@ class TestIntegrationLoad:
 class TestIntegrationLoadAll:
     def test_load_all_returns_stacked_table(self):
         t = phangs.load_all(DATA_DIR, aperture="annulus")
+        assert isinstance(t, dict)
+        t = phangs.vstack_tables(t)
         assert isinstance(t, Table)
         assert len(t) > 0
         assert "GALAXY" in t.colnames
 
     def test_load_all_contains_multiple_galaxies(self):
         t = phangs.load_all(DATA_DIR, aperture="annulus")
+        t = phangs.vstack_tables(t)
         assert len(set(t["GALAXY"])) > 1

--- a/tests/test_phangs.py
+++ b/tests/test_phangs.py
@@ -283,6 +283,7 @@ class TestRunPRFM:
             r_gal V_circ_CO21_URC Sigma_mol Sigma_atom Sigma_star rho_star_mp Sigma_SFR_HaW4recal Zprime
             1.0 150.0 10.0 5.0 200.0 0.1 0.01 1.0
             2.0 180.0 nan 4.0 150.0 0.08 0.008 0.9
+            3.0 200.0 nan nan 100.0 0.05 0.005 0.8
         """)
         f = tmp_path / "TESTNAN_annulus_0p5kpc.ecsv"
         f.write_text(ecsv_nan)
@@ -291,7 +292,10 @@ class TestRunPRFM:
         with warnings.catch_warnings(record=True):
             out = phangs.run_prfm(t)
         assert np.isfinite(out["Sigma_SFR_pred"].value[0])
-        assert np.isnan(out["Sigma_SFR_pred"].value[1])
+        # mol=nan, atom=valid → Sigma_gas filled with atom only → valid output
+        assert np.isfinite(out["Sigma_SFR_pred"].value[1])
+        # both mol and atom nan → Sigma_gas=nan → output must be nan
+        assert np.isnan(out["Sigma_SFR_pred"].value[2])
 
     def test_sfr_pred_positive_for_valid_rows(self, synthetic_table):
         out = phangs.run_prfm(synthetic_table)

--- a/tests/test_prfm.py
+++ b/tests/test_prfm.py
@@ -1,0 +1,301 @@
+"""
+Unit tests for prfm.prfm based on the toy galaxy model from book/prfm.ipynb.
+
+The reference model is a radial profile (R=2-16 kpc) with:
+  - Sigma_gas = 10 / (R/R0)  [M_sun/pc^2]  (linear in R)
+  - Sigma_star = 42 * exp(R0/Re - R/Re)    (exponential disk)
+  - Omega_d = 28 / (R/R0)   [km/s/kpc]     (flat rotation curve)
+  - H_star = 245             [pc]            (no flaring)
+  - sigma_eff = 15           [km/s]          (constant)
+"""
+
+import numpy as np
+import pytest
+
+import prfm
+from prfm.prfm import (
+    _Gconst_cgs,
+    _kbol_cgs,
+    _pc_cgs,
+    _sfr_cgs,
+    _surf_cgs,
+    get_feedback_yield,
+    get_feedback_yield_comp,
+    get_pressure,
+    get_sfr,
+    get_sigma_eff,
+    get_weight_dm,
+    get_weight_gas,
+    get_weight_star,
+)
+
+# ---------------------------------------------------------------------------
+# Shared toy-galaxy fixture
+# ---------------------------------------------------------------------------
+
+_kms_kpc_cgs = 1.0e5 / (3.085677581e21)  # km/s/kpc -> 1/s
+
+
+@pytest.fixture(scope="module")
+def toy_model():
+    """Toy galaxy radial profile matching the notebook example."""
+    R0, Re = 8.0, 3.5
+    R = np.linspace(2, 16, 100)
+    r0 = R / R0
+    re = R / Re
+
+    Sigma_gas = 10.0 / r0
+    Sigma_star = 42.0 * np.exp(R0 / Re - re)
+    Omega_d = 28.0 / r0
+    H_star = 245.0
+    sigma_eff = 15.0
+
+    return dict(
+        Sigma_gas=Sigma_gas,
+        Sigma_star=Sigma_star,
+        Omega_d=Omega_d,
+        H_star=H_star,
+        sigma_eff=sigma_eff,
+    )
+
+
+@pytest.fixture(scope="module")
+def toy_model_cgs():
+    """Same toy galaxy in CGS."""
+    R0, Re = 8.0, 3.5
+    R = np.linspace(2, 16, 100)
+    r0 = R / R0
+    re = R / Re
+
+    return dict(
+        Sigma_gas=10.0 / r0 * _surf_cgs,
+        Sigma_star=42.0 * np.exp(R0 / Re - re) * _surf_cgs,
+        Omega_d=28.0 / r0 * _kms_kpc_cgs,
+        H_star=245.0 * _pc_cgs,
+        sigma_eff=15.0 * 1.0e5,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Low-level weight & pressure functions
+# ---------------------------------------------------------------------------
+
+
+class TestWeightFunctions:
+    """Physics checks on the primitive CGS weight functions."""
+
+    # Solar-circle CGS reference values
+    Sg = 10.0 * _surf_cgs
+    Ss = 42.0 * _surf_cgs
+    Hs = 245.0 * _pc_cgs
+    Hg = 100.0 * _pc_cgs
+    Od = 28.0 * _kms_kpc_cgs
+    se = 15.0 * 1.0e5
+
+    def test_weight_gas_formula(self):
+        """W_gas = 0.5 * pi * G * Sigma_gas^2"""
+        expected = 0.5 * np.pi * _Gconst_cgs * self.Sg**2
+        assert np.isclose(get_weight_gas(self.Sg), expected)
+
+    def test_weight_gas_scales_as_sigma_squared(self):
+        w1 = get_weight_gas(self.Sg)
+        w2 = get_weight_gas(2.0 * self.Sg)
+        assert np.isclose(w2 / w1, 4.0)
+
+    def test_weight_star_formula(self):
+        """W_star = pi * G * Sigma_gas * Sigma_star * H_gas / (H_gas + H_star)"""
+        expected = np.pi * _Gconst_cgs * self.Sg * self.Ss * self.Hg / (self.Hg + self.Hs)
+        assert np.isclose(get_weight_star(self.Sg, self.Hg, self.Ss, self.Hs), expected)
+
+    def test_weight_star_approaches_thin_limit(self):
+        """For H_gas >> H_star, W_star -> pi*G*Sigma_gas*Sigma_star (thin-disk limit)."""
+        W = get_weight_star(self.Sg, 1e10 * self.Hg, self.Ss, self.Hs)
+        thin = np.pi * _Gconst_cgs * self.Sg * self.Ss
+        assert np.isclose(W, thin, rtol=1e-4)
+
+    def test_weight_dm_formula(self):
+        """W_dm = zeta_d * Sigma_gas * H_gas * Omega_d^2"""
+        zeta_d = 1.0 / 3.0
+        expected = zeta_d * self.Sg * self.Hg * self.Od**2
+        assert np.isclose(get_weight_dm(self.Sg, self.Hg, self.Od), expected)
+
+    def test_pressure_formula(self):
+        """P = 0.5 * Sigma_gas / H_gas * sigma_eff^2"""
+        expected = 0.5 * self.Sg / self.Hg * self.se**2
+        assert np.isclose(get_pressure(self.Sg, self.Hg, self.se), expected)
+
+    def test_pressure_weight_balance_at_equilibrium(self, toy_model_cgs):
+        """At equilibrium H, total pressure should equal total weight."""
+        d = toy_model_cgs
+        # Use PRFM class to find equilibrium H, then check P = W_tot
+        m = prfm.PRFM(**{k: v / (1e5 if k == "sigma_eff" else (_surf_cgs if "Sigma" in k else (_pc_cgs if "H" in k else _kms_kpc_cgs))) for k, v in d.items()}, astro_units=True)
+        m.calc_weights()
+        P = get_pressure(d["Sigma_gas"], m._H_gas, d["sigma_eff"])
+        np.testing.assert_allclose(P, m._Wtot, rtol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Scale height: analytic vs. numerical consistency
+# ---------------------------------------------------------------------------
+
+
+WEIGHT_COMBOS = [
+    (1, 0, 0),  # gas only
+    (0, 1, 0),  # star only
+    (0, 0, 1),  # dm only
+    (1, 1, 0),  # gas + star
+    (1, 0, 1),  # gas + dm
+    (1, 1, 1),  # full
+]
+
+
+@pytest.mark.parametrize("wgas,wstar,wdm", WEIGHT_COMBOS)
+def test_analytic_numerical_scale_height_agreement(toy_model, wgas, wstar, wdm):
+    """Analytic and numerical scale heights must agree to within 1% across the radial profile."""
+    m = prfm.PRFM(**toy_model, astro_units=True)
+    H_ana = m.get_scale_height(method="analytic", wgas=wgas, wstar=wstar, wdm=wdm)
+    H_num = m.get_scale_height(method="numerical", wgas=wgas, wstar=wstar, wdm=wdm)
+    np.testing.assert_allclose(H_ana, H_num, rtol=0.01, err_msg=f"wgas={wgas} wstar={wstar} wdm={wdm}")
+
+
+# ---------------------------------------------------------------------------
+# PRFM class: weights and weight contributions
+# ---------------------------------------------------------------------------
+
+
+class TestPRFMWeights:
+    def test_calc_weights_sets_attributes(self, toy_model):
+        m = prfm.PRFM(**toy_model, astro_units=True)
+        m.calc_weights()
+        for attr in ["H_gas", "Wgas", "Wstar", "Wdm", "Wtot"]:
+            assert hasattr(m, attr), f"missing attribute {attr}"
+            assert np.all(np.isfinite(getattr(m, attr))), f"{attr} contains non-finite values"
+
+    def test_weight_contributions_sum_to_one(self, toy_model):
+        m = prfm.PRFM(**toy_model, astro_units=True)
+        m.calc_weights()
+        fgas, fstar, fdm = m.get_weight_contribution()
+        np.testing.assert_allclose(fgas + fstar + fdm, 1.0, rtol=1e-10)
+
+    def test_weight_contributions_non_negative(self, toy_model):
+        m = prfm.PRFM(**toy_model, astro_units=True)
+        m.calc_weights()
+        fgas, fstar, fdm = m.get_weight_contribution()
+        assert np.all(fgas >= 0) and np.all(fstar >= 0) and np.all(fdm >= 0)
+
+    def test_wtot_equals_sum_of_components(self, toy_model):
+        m = prfm.PRFM(**toy_model, astro_units=True)
+        m.calc_weights()
+        np.testing.assert_allclose(m.Wgas + m.Wstar + m.Wdm, m.Wtot, rtol=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Self-consistent solutions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "sigma_eff_model",
+    [15.0, "tigress-classic-mid", "tigress-classic-avg"],
+    ids=["constant", "tigress-classic-mid", "tigress-classic-avg"],
+)
+@pytest.mark.parametrize("method", ["analytic", "numerical"])
+def test_self_consistent_solution(toy_model, sigma_eff_model, method):
+    """Self-consistent solution converges and produces positive, finite outputs."""
+    params = {**toy_model, "sigma_eff": sigma_eff_model}
+    m = prfm.PRFM(**params, astro_units=True)
+    H = m.calc_self_consistent_solution(method=method)
+    assert np.all(np.isfinite(H)), "H_gas contains non-finite values"
+    assert np.all(H > 0), "H_gas contains non-positive values"
+    assert np.all(np.isfinite(m.Wtot))
+    assert np.all(m.Wtot > 0)
+
+
+def test_model_sigma_eff_consistent_with_pressure(toy_model):
+    """For a sigma_eff model, sigma_eff stored in the PRFM object must match
+    what get_sigma_eff returns for the converged pressure."""
+    params = {**toy_model, "sigma_eff": "tigress-classic-mid"}
+    m = prfm.PRFM(**params, astro_units=True)
+    m.calc_self_consistent_solution()
+    expected_sigma = get_sigma_eff(m._Wtot, model="tigress-classic-mid")
+    np.testing.assert_allclose(m._sigma_eff, expected_sigma, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Feedback yield models
+# ---------------------------------------------------------------------------
+
+
+class TestFeedbackYield:
+    # Reference pressure ~ 1e4 k_B cm^-3 K in CGS
+    P_ref = 1.0e4 * _kbol_cgs
+
+    def test_classic_yield_positive(self):
+        Y = get_feedback_yield(self.P_ref, model="tigress-classic")
+        assert Y > 0
+
+    def test_decomp_yield_equals_sum_of_components(self):
+        P = self.P_ref
+        Ytot = get_feedback_yield(P, model="tigress-classic-decomp")
+        Yth = get_feedback_yield_comp(P, comp="th", model="tigress-classic-decomp")
+        Ytrb = get_feedback_yield_comp(P, comp="trb", model="tigress-classic-decomp")
+        assert np.isclose(Ytot, Yth + Ytrb)
+
+    def test_ncr_decomp_all_yield_positive(self):
+        Y = get_feedback_yield(self.P_ref, Z=1.0, model="tigress-ncr-decomp-all")
+        assert Y > 0
+
+    def test_yield_decreases_with_pressure_classic(self):
+        """Classic model has negative slope — higher P gives lower yield."""
+        Y_lo = get_feedback_yield(self.P_ref, model="tigress-classic")
+        Y_hi = get_feedback_yield(10 * self.P_ref, model="tigress-classic")
+        assert Y_hi < Y_lo
+
+    @pytest.mark.parametrize(
+        "model",
+        ["tigress-classic", "tigress-classic-decomp", "tigress-ncr", "tigress-ncr-decomp"],
+    )
+    def test_yield_model_returns_positive_array(self, model):
+        P = self.P_ref * np.logspace(-1, 2, 20)
+        kwargs = {"Z": 1.0} if "ncr" in model else {}
+        Y = get_feedback_yield(P, model=model, **kwargs)
+        assert np.all(Y > 0)
+
+
+# ---------------------------------------------------------------------------
+# SFR calculation
+# ---------------------------------------------------------------------------
+
+
+class TestSFRCalculation:
+    def test_sfr_positive_constant_yield(self, toy_model):
+        m = prfm.PRFM(**toy_model, astro_units=True)
+        m.calc_self_consistent_solution()
+        Sigma_SFR = m.calc_sfr(Ytot=1.0e3)
+        assert np.all(Sigma_SFR > 0)
+
+    @pytest.mark.parametrize(
+        "ytot_model", ["tigress-classic", "tigress-classic-decomp"]
+    )
+    def test_sfr_positive_yield_model(self, toy_model, ytot_model):
+        m = prfm.PRFM(**toy_model, astro_units=True)
+        m.calc_self_consistent_solution()
+        Sigma_SFR = m.calc_sfr(Ytot=ytot_model)
+        assert np.all(Sigma_SFR > 0)
+        assert np.all(np.isfinite(Sigma_SFR))
+
+    def test_sfr_inversely_proportional_to_yield(self, toy_model):
+        """Doubling Ytot should halve Sigma_SFR."""
+        m = prfm.PRFM(**toy_model, astro_units=True)
+        m.calc_self_consistent_solution()
+        sfr1 = m.calc_sfr(Ytot=500.0).copy()
+        sfr2 = m.calc_sfr(Ytot=1000.0).copy()
+        np.testing.assert_allclose(sfr1 / sfr2, 2.0, rtol=1e-10)
+
+    def test_sfr_function_agrees_with_class(self, toy_model):
+        """get_sfr functional API should match PRFM.calc_sfr."""
+        m = prfm.PRFM(**toy_model, astro_units=True)
+        m.calc_self_consistent_solution()
+        Sigma_SFR_class = m.calc_sfr(Ytot=1.0e3)
+        Sigma_SFR_func = get_sfr(m._Wtot, Ytot=1.0e3) / _sfr_cgs
+        np.testing.assert_allclose(Sigma_SFR_class, Sigma_SFR_func, rtol=1e-10)


### PR DESCRIPTION
## Summary

Adds the \`prfm.phangs\` module for downloading, loading, and analyzing the PHANGS megatable (Sun et al. 2022/2023 v4.0), and a worked notebook reproducing Sun+2023 Figure 4 using the PRFM model.

## Task checklist

- [x] Add \`prfm/phangs.py\` module (\`download\`, \`load\`, \`load_all\`, \`compute_prfm_inputs\`, \`valid_rows\`)
- [x] Add unit tests (\`tests/test_phangs.py\`) with synthetic ECSV fixture (no data required)
- [x] Add integration tests (auto-skipped in CI, runnable locally after download)
- [x] Add CLI download script (\`scripts/download_phangs.py\`)
- [x] Configure GitHub Actions to run unit tests only (\`-m "not integration"\`)
- [x] Add \`run_prfm()\` convenience function to \`prfm/phangs.py\`
- [x] Add \`get_weights()\` convenience function to \`prfm/phangs.py\`
- [x] Add \`variation\` parameter to \`run_prfm()\` for sensitivity tests
- [x] Add \`rel_error\` parameter to \`valid_rows()\` for quality filtering
- [x] Fill \`Sigma_gas\` NaN components with 0 when the other component is detected
- [x] Add \`prfm/phangs_plot.py\` module with \`scatter_plot\`, \`hist_plot\`, \`plot_weights\`, and helpers
- [x] Refactor exploration scripts to import from \`phangs_plot\`
- [x] \`book/prfm_phangs.ipynb\` — Data loading & NaN coverage (hexagon aperture)
- [x] \`book/prfm_phangs.ipynb\` — 7×7 correlation scatter/histogram matrix
- [x] \`book/prfm_phangs.ipynb\` — PRFM predictions (\`run_prfm\`)
- [x] \`book/prfm_phangs.ipynb\` — Weight fractions vs P_DE with binned means
- [x] \`book/prfm_phangs.ipynb\` — P_DE vs Σ_gas and Σ_star
- [x] \`book/prfm_phangs.ipynb\` — Reproduce Sun+2023 Figure 4 (P_DE vs Σ_SFR + TIGRESS overlay)
- [x] Exclude \`prfm_phangs.ipynb\` from jupyter-book execution (uses stored outputs)
- [x] Add unit tests for \`run_prfm()\` in \`tests/test_phangs.py\`
- [x] Update \`book/api.rst\` with PHANGS utilities
- [x] Verify integration tests pass with downloaded data

## Data

Download the full PHANGS dataset locally (not committed, ~10 MB for annulus):
```bash
python scripts/download_phangs.py
```

## Running tests

```bash
# Unit tests only (CI)
pytest tests/test_phangs.py -v -m "not integration"

# All tests including integration (requires downloaded data)
pytest tests/test_phangs.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)